### PR TITLE
Refactor/checking and documenting

### DIFF
--- a/src/attendance/attendance.controller.ts
+++ b/src/attendance/attendance.controller.ts
@@ -1,33 +1,45 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { AttendanceService } from './attendance.service';
 import { CreateAttendanceDto } from '../dbmanager/dto/create-attendance.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 
-@ApiTags('attendance')
+@ApiTags('Attendance')
 @Controller('attendance')
 export class AttendanceController {
-	constructor(private attendanceService: AttendanceService) {}
+	constructor(private readonly attendanceService: AttendanceService) {}
 
+	// GET /attendance/{intraId}/buttonStatus
+	@Get('/:intraId/buttonStatus')
 	@ApiOperation({summary: 'get the attendance button status of the user'})
 	@ApiParam({
 		name: 'intraId',
-		type: 'string',
+		type: String,
 	})
-	@ApiOkResponse({
-		description: 'Success'
+	@ApiResponse({
+		status: 200, 
+		description: 'Success', 
+		type: Number
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
 	})
 	@UseGuards(JwtAuthGuard)
-	@Get('/:intraId/buttonStatus') // 유저 출석체크 버튼의 상태
-	getUserButtonStatus(@Param('intraId') intraId: string) {
-		console.log(intraId);
+	async getUserButtonStatus(@Param('intraId') intraId: string): Promise<number> {
+		console.log("In AttendanceController.getUserButtonStatus");
+		console.log(`API[ GET /attendance/${intraId}/buttonStatus ] requested`)
 		return this.attendanceService.getUserButtonStatus(intraId);
 	}
 
-	@UseGuards(JwtAuthGuard)
+	// todo -> type: AttendanceButtonStatusDto
 	@Post('/userAttendance') // 유저 출석체크 인증
+	@UseGuards(JwtAuthGuard)
 	pushButton(@Body() createAttendanceDto: CreateAttendanceDto) {
 		return this.attendanceService.AttendanceCertification(createAttendanceDto);
 	}
-
 }

--- a/src/attendance/attendance.service.ts
+++ b/src/attendance/attendance.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { DbmanagerService } from 'src/dbmanager/dbmanager.service';
 import { DayInfo } from '../dbmanager/entities/day_info.entity';
 import { UserInfo } from '../dbmanager/entities/user_info.entity';
-import { CreateAttendanceDto } from '../dbmanager/dto/create-attendance.dto';
+import { CreateAttendanceDto } from './dto/create-attendance.dto';
 import { OperatorService } from '../operator/operator.service';
 import { MonthInfo } from '../dbmanager/entities/month_info.entity';
 
@@ -11,12 +11,11 @@ export class AttendanceService {
 	@Inject(DbmanagerService) private readonly dbmanagerService: DbmanagerService;
 	@Inject(OperatorService) private readonly operatorService: OperatorService;
 
-
 	async getUserButtonStatus(intraId: string): Promise<number> {
-		// // if (!this.isAvailableTime()) {
-		// // 	return (1);
-		// // }
-		if (await this.isAttendance(intraId)) {
+		if (this.isAvailableTime() === false) {
+			return (1);
+		}
+		else if (await this.haveAttendedToday(intraId)) {
 			return (2);
 		}
 		// else if (await !this.isSetToDayWord()) {
@@ -25,28 +24,29 @@ export class AttendanceService {
 		return (0);
 	}
 
+	// 이거 user에도 있음. 확인 필요.
 	async AttendanceCertification(attendanceinfo: CreateAttendanceDto) {
-		const toDayWord: string = await this.dbmanagerService.getToDayWord();
+		const todayWord: string = await this.dbmanagerService.getTodayWord();
 		const monthInto: MonthInfo = await this.dbmanagerService.getThisMonthInfo();
-		if (await this.isAttendance(attendanceinfo.intraId)) {
+		const userIntraId = attendanceinfo.intraId;
+		if (await this.haveAttendedToday(userIntraId)) {
 			return ({
 				statusAttendance: 1,
 				errorMsg: "이미 출석 체크 했습니다."
 			});
 		}
-		if (attendanceinfo.todayWord !== toDayWord) {
+		if (attendanceinfo.todayWord !== todayWord) {
 			return ({
 				statusAttendance: 2,
 				errorMsg: "오늘의 단어가 다릅니다."
 			});
 		}
-		let monthlyUser = await this.dbmanagerService.getThisMonthlyUser(attendanceinfo.intraId);
+		let monthlyUser = await this.dbmanagerService.getThisMonthlyUser(userIntraId);
 		if (!monthlyUser)
-			monthlyUser = await this.dbmanagerService.createMonthlyUser(attendanceinfo.intraId);
-		console.log(monthlyUser);
+			monthlyUser = await this.dbmanagerService.createMonthlyUser(userIntraId);
 		await this.dbmanagerService.attendanceRegistration(attendanceinfo);
 		await this.dbmanagerService.updateMonthlyUser(monthlyUser);
-		await this.operatorService.statusUpdate(monthlyUser, monthInto.currentAttendance);
+		await this.operatorService.updatePerfectStatus(monthlyUser, monthInto.currentAttendance);
 		return ({
 			statusAttendance: 0,
 			errorMsg: "성공적으로 출석 체크를 완료했습니다."
@@ -58,31 +58,31 @@ export class AttendanceService {
      * 			util function list     *
      ********************************* */
 	
-	isAvailableTime() {
+	isAvailableTime(): Boolean {
 		const now = new Date();
 		const start = new Date();
 		const end = new Date();
 		start.setHours(8, 30, 0);
 		end.setHours(9, 0, 0);
 		if (now < start || now > end)
-			return (0);		
+			return (false);
 		else
-			return (1);
+			return (true);
 	}
 
-	async isAttendance(intra_id: string): Promise<boolean> {
-		const dayInfo: DayInfo = await this.dbmanagerService.getDayInfo();
+	async haveAttendedToday(intra_id: string): Promise<boolean> {
+		const todayInfo: DayInfo = await this.dbmanagerService.getTodayInfo();
 		const userInfo: UserInfo = await this.dbmanagerService.getUserInfo(intra_id)
-		const found = await this.dbmanagerService.getAttendanceUserInfo(userInfo, dayInfo);
-		if (found === null)
+		const todayAttendanceInfo = await this.dbmanagerService.getAttendanceUserInfo(userInfo, todayInfo);
+		if (todayAttendanceInfo === null)
 			return false;
 		else
 			return true;
 	}
 
-	async isSetToDayWord(): Promise<boolean> {
-		const found: DayInfo = await this.dbmanagerService.getDayInfo();
-		if (found.todayWord === "뀨?")
+	async isTodayWordSet(): Promise<boolean> {
+		const todayInfo: DayInfo = await this.dbmanagerService.getTodayInfo();
+		if (todayInfo.todayWord === "뀨?")
 			return (false);
 		else
 			return (true);

--- a/src/attendance/dto/create-attendance.dto.ts
+++ b/src/attendance/dto/create-attendance.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateAttendanceDto {
+	@ApiProperty()
+	intraId: string;
+
+	@ApiProperty()
+	todayWord: string;
+}

--- a/src/attendance/dto/create-user.dto.ts
+++ b/src/attendance/dto/create-user.dto.ts
@@ -1,4 +1,10 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+// dto가 dbmanager, attendance에 다 있는데 둘 중에 뭐가 진짜임?
 export class CreateUserDto {
+    @ApiProperty()
     intraId: string;
+
+    @ApiProperty()
     password: string;
 }

--- a/src/attendance/dto/create-user.dto.ts
+++ b/src/attendance/dto/create-user.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
 
-// dto가 dbmanager, attendance에 다 있는데 둘 중에 뭐가 진짜임?
 export class CreateUserDto {
     @ApiProperty()
     intraId: string;

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -89,11 +89,13 @@ export class AuthController {
 	})
   async firstJoin(@Query('code') code: string)
   {
-    console.log("firstJoin 확인");
+    console.log("[GET /serverAuth/firstJoin] requested.");
+    console.log("[42OAuth code]:");
     console.log(code);
 
-    //회원가입 유무는 여기서
+    // todo: Rename to checkingAlreadySignedIn
     const userInfo = await this.authService.firstJoin(code);
+    console.log("[userInfo]:");
     console.log(userInfo);
     return(userInfo);
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,7 +15,9 @@ export class AuthController {
     private jwtService: JwtService
     ) {}
 
-  // POST /serverAuth/login
+  /**
+   * POST /serverAuth/login
+   */
   @Post('login')
 	@ApiOperation({summary: 'request user login'})
 	@ApiResponse({
@@ -39,6 +41,9 @@ export class AuthController {
     return ;
   }
 
+  /**
+   * POST /serverAuth/logout
+   */
   @Post('logout')
   @ApiOperation({summary: 'request user logout'})
 	@ApiResponse({
@@ -51,14 +56,21 @@ export class AuthController {
 	})
   logout(@Res() response:Response)
   {
-    //쿠키 자용시
-    response.cookie("accessToken","",
-    {
-      httpOnly: true,
-      maxAge: 0
-    })
+    /** 
+     * When using cookie (saving accessToken in cookie), run below code.
+     */
+    // response.cookie("accessToken","",
+    // {
+    //   httpOnly: true,
+    //   maxAge: 0
+    // })
+
+    /** 
+     * When using local storage, the front-end removes the accessToken.
+     */
+
     response.send({message:'로그아웃'});
-    //로컬스토리지는 프론트엔드에서 로컬스토리지에 토큰 지우는 방식으로
+    return ;
   }
 
   @Get('firstJoin')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,9 +5,9 @@ import { Token } from './auth.decorator';
 import { JwtService } from '@nestjs/jwt';
 import { JwtAuthGuard } from './guard/jwt-auth.guard';
 import { AuthDto } from './dto/auth.dto';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-@ApiTags('auth')
+@ApiTags('Auth')
 @Controller('serverAuth')
 export class AuthController {
   constructor(
@@ -15,35 +15,44 @@ export class AuthController {
     private jwtService: JwtService
     ) {}
 
+  // test
   @Get('oauth')
+  @ApiOperation({summary: 'for testing'})
   @Redirect('https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-fe0450158bd57a0967d25286f60a880e9dfeaf974652aa249d4b9700a2251a1b&redirect_uri=http%3A%2F%2F10.19.247.186%3A3042%2Fauth%2FfirstJoin&response_type=code', 301)
   redi()
   {
     return("redi");
   }
 
+  // POST /serverAuth/login
   @Post('login')
-  async login(@Res() response:Response, @Body() authDto:AuthDto)
+	@ApiOperation({summary: 'request user login'})
+	@ApiResponse({
+		status: 201, 
+		description: 'Success'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
+  async login(@Res() response: Response, @Body() authDto: AuthDto)
   {
     console.log('login');
     console.log(authDto);
     response.send({accessToken: await this.authService.login(response, authDto)});
-
-    // response.setHeader('Set-cookie', await this.authService.login(response, authDto));
-    // response.cookie("accessToken", await this.authService.login(response, authDto),
-    // {
-    //   httpOnly: true,
-    //   secure: true,
-    //   sameSite: "none",
-    //   maxAge: 24 * 60 * 60 * 1000 //1 day
-    // }
-    // );
-    // console.log(response);
-    // return(response.send({message:'로그인 성공'}));
-    // return("로그인 확인")
+    // todo: specifying returning
   }
 
   @Post('logout')
+  @ApiOperation({summary: 'request user logout'})
+	@ApiResponse({
+		status: 201, 
+		description: 'Success'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
   logout(@Res() response:Response)
   {
     //쿠키 자용시
@@ -57,6 +66,16 @@ export class AuthController {
   }
 
   @Get('firstJoin')
+  @ApiOperation({summary: 'get a user info from 42OAuth'})
+	@ApiResponse({
+		status: 200, 
+		description: 'Success', 
+    type: AuthDto
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
   async firstJoin(@Query('code') code: string)
   {
     console.log("firstJoin 확인");
@@ -69,6 +88,16 @@ export class AuthController {
   }
 
   @Post('secondJoin')
+  @ApiOperation({summary: 'request user join'})
+	@ApiResponse({
+		status: 201, 
+		description: 'Success',
+    type: String
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
   async secondJoin(@Body() authDto:AuthDto)
   {
     console.log("secondJoin 확인");
@@ -76,15 +105,18 @@ export class AuthController {
     return(await this.authService.secondJoin(authDto));
   }
 
-
+  // test
   @Get('test0')
+  @ApiOperation({summary: 'for testing'})
   test0()
   {
     console.log("hello");
     return("test0")
   }
   
+  // test
   @Post('test')
+  @ApiOperation({summary: 'for testing'})
   async test(@Body() authDto: AuthDto)
   {
     // response.cookie("accessToken", this.authService.createrAcessToken(authDto),
@@ -98,7 +130,9 @@ export class AuthController {
     return (this.authService.createrAcessToken(authDto));
   }
 
+  // test
   @Post('test2')
+  @ApiOperation({summary: 'for testing'})
   test2(@Token() token:string)
   {
     console.log(this.jwtService.verify(token));
@@ -106,8 +140,10 @@ export class AuthController {
     return ("test2 리턴")
   }
 
+  // test
   @UseGuards(JwtAuthGuard)
   @Post('test3')
+  @ApiOperation({summary: 'for testing'})
   test3(@Token() token:string)
   {
     console.log(this.jwtService.verify(token));

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -25,8 +25,8 @@ export class AuthController {
 		description: 'Success'
 	})
 	@ApiResponse({
-		status: 403,
-		description: 'Forbidden'
+		status: 401,
+		description: 'Unauthorized'
 	})
   async login(@Res() response: Response, @Body() authDto: AuthDto)
   {
@@ -73,6 +73,9 @@ export class AuthController {
     return ;
   }
 
+  /**
+   * GET /serverAuth/firstJoin
+   */
   @Get('firstJoin')
   @ApiOperation({summary: 'get a user info from 42OAuth'})
 	@ApiResponse({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,24 +5,15 @@ import { Token } from './auth.decorator';
 import { JwtService } from '@nestjs/jwt';
 import { JwtAuthGuard } from './guard/jwt-auth.guard';
 import { AuthDto } from './dto/auth.dto';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Auth')
 @Controller('serverAuth')
 export class AuthController {
   constructor(
-    private readonly authService: AuthService,
+    private authService: AuthService,
     private jwtService: JwtService
     ) {}
-
-  // test
-  @Get('oauth')
-  @ApiOperation({summary: 'for testing'})
-  @Redirect('https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-fe0450158bd57a0967d25286f60a880e9dfeaf974652aa249d4b9700a2251a1b&redirect_uri=http%3A%2F%2F10.19.247.186%3A3042%2Fauth%2FfirstJoin&response_type=code', 301)
-  redi()
-  {
-    return("redi");
-  }
 
   // POST /serverAuth/login
   @Post('login')
@@ -37,10 +28,15 @@ export class AuthController {
 	})
   async login(@Res() response: Response, @Body() authDto: AuthDto)
   {
-    console.log('login');
+    console.log("[POST /serverAuth/login] requested.");
+    console.log("[AuthoDto]:")
     console.log(authDto);
-    response.send({accessToken: await this.authService.login(response, authDto)});
-    // todo: specifying returning
+
+    const accessToken = await this.authService.login(response, authDto);
+    console.log("[accessToken]:");
+    console.log(accessToken);
+    response.send({ accessToken });
+    return ;
   }
 
   @Post('logout')
@@ -105,6 +101,7 @@ export class AuthController {
     return(await this.authService.secondJoin(authDto));
   }
 
+  // todo: Remove
   // test
   @Get('test0')
   @ApiOperation({summary: 'for testing'})
@@ -114,8 +111,19 @@ export class AuthController {
     return("test0")
   }
   
+  // todo: Remove
   // test
   @Post('test')
+	@ApiCreatedResponse({
+		description: '테스트',
+		schema: {
+			example: {
+				intraId: 'mgo',
+				isOperator: true,
+				photoUrl: 'https://awesome.photo'
+			}
+		}
+	})
   @ApiOperation({summary: 'for testing'})
   async test(@Body() authDto: AuthDto)
   {
@@ -130,6 +138,7 @@ export class AuthController {
     return (this.authService.createrAcessToken(authDto));
   }
 
+  // todo: Remove
   // test
   @Post('test2')
   @ApiOperation({summary: 'for testing'})
@@ -140,6 +149,7 @@ export class AuthController {
     return ("test2 리턴")
   }
 
+  // todo: Remove
   // test
   @UseGuards(JwtAuthGuard)
   @Post('test3')
@@ -149,6 +159,15 @@ export class AuthController {
     console.log(this.jwtService.verify(token));
     console.log("토큰 " + token);
     return ("test3 리턴")
+  }
+
+  // todo: Remove
+  @Get('oauth')
+  @ApiOperation({summary: 'for testing'})
+  @Redirect('https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-fe0450158bd57a0967d25286f60a880e9dfeaf974652aa249d4b9700a2251a1b&redirect_uri=http%3A%2F%2F10.19.247.186%3A3042%2Fauth%2FfirstJoin&response_type=code', 301)
+  redi()
+  {
+    return("redi");
   }
 
   @Delete('delete')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -28,8 +28,7 @@ export class AuthController {
 		status: 401,
 		description: 'Unauthorized'
 	})
-  async login(@Res() response: Response, @Body() authDto: AuthDto)
-  {
+  async login(@Res() response: Response, @Body() authDto: AuthDto) {
     console.log("[POST /serverAuth/login] requested.");
     console.log("[AuthoDto]:")
     console.log(authDto);
@@ -54,8 +53,7 @@ export class AuthController {
 		status: 403,
 		description: 'Forbidden'
 	})
-  logout(@Res() response:Response)
-  {
+  logout(@Res() response:Response) {
     /** 
      * When using cookie (saving accessToken in cookie), run below code.
      */
@@ -87,8 +85,7 @@ export class AuthController {
 		status: 403,
 		description: 'Forbidden'
 	})
-  async firstJoin(@Query('code') code: string)
-  {
+  async firstJoin(@Query('code') code: string) {
     console.log("[GET /serverAuth/firstJoin] requested.");
     console.log("[42OAuth code]:");
     console.log(code);
@@ -111,9 +108,9 @@ export class AuthController {
 		status: 403,
 		description: 'Forbidden'
 	})
-  async secondJoin(@Body() authDto:AuthDto)
-  {
-    console.log("secondJoin 확인");
+  async secondJoin(@Body() authDto:AuthDto) {
+    console.log("[POST /serverAuth/secondJoin] requested.");
+    console.log("[authDto]:");
     console.log(authDto);
     return(await this.authService.secondJoin(authDto));
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -30,7 +30,7 @@ export class AuthController {
 	})
   async login(@Res() response: Response, @Body() authDto: AuthDto) {
     console.log("[POST /serverAuth/login] requested.");
-    console.log("[AuthoDto]:")
+    console.log("Body [AuthoDto]:")
     console.log(authDto);
 
     const accessToken = await this.authService.login(response, authDto);
@@ -72,7 +72,7 @@ export class AuthController {
   }
 
   /**
-   * GET /serverAuth/firstJoin
+   * GET /serverAuth/firstJoin?code=
    */
   @Get('firstJoin')
   @ApiOperation({summary: 'get a user info from 42OAuth'})
@@ -87,7 +87,7 @@ export class AuthController {
 	})
   async firstJoin(@Query('code') code: string) {
     console.log("[GET /serverAuth/firstJoin] requested.");
-    console.log("[42OAuth code]:");
+    console.log("Query [42OAuth code]:");
     console.log(code);
 
     // todo: Rename to checkingAlreadySignedIn
@@ -97,8 +97,11 @@ export class AuthController {
     return(userInfo);
   }
 
+  /**
+   * POST /serverAuth/secondJoin
+   */
   @Post('secondJoin')
-  @ApiOperation({summary: 'request user join'})
+  @ApiOperation({summary: 'request a user sign-in'})
 	@ApiResponse({
 		status: 201, 
 		description: 'Success',
@@ -110,9 +113,24 @@ export class AuthController {
 	})
   async secondJoin(@Body() authDto:AuthDto) {
     console.log("[POST /serverAuth/secondJoin] requested.");
-    console.log("[authDto]:");
+    console.log("Body [authDto]:");
     console.log(authDto);
     return(await this.authService.secondJoin(authDto));
+  }
+
+  // todo: Set in UserController
+  // todo: checking when error
+  /**
+   * DELETE /serverAuth/delete?intraId=
+   */
+  @Delete('delete')
+  @ApiOperation({summary: 'remove a user info'})
+  async deleteUser(@Query('intraId') intraId:string) {
+    console.log("[DELETE /serverAuth/delete] requested.");
+    console.log("Query [intraId]");
+    console.log(intraId);
+    console.log(await this.authService.deleteUser(intraId)); // todo: consider
+    console.log(intraId + " 삭제완료");
   }
 
   // todo: Remove
@@ -182,12 +200,5 @@ export class AuthController {
   redi()
   {
     return("redi");
-  }
-
-  @Delete('delete')
-  async DeleteUser(@Query('intraId') intraId:string)
-  {
-    console.log(await this.authService.DeleteUser(intraId));
-    console.log(intraId + " 삭제완료");
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -75,7 +75,7 @@ export class AuthService {
       })
       .catch((err) => {
         console.log("getUserData from 42api 에러");
-        
+
         // todo: consider
         throw new HttpException('42회원 정보가 존재하지 않습니다.', HttpStatus.FORBIDDEN);
       });
@@ -130,24 +130,25 @@ export class AuthService {
     const user = new UserInfo();
     const saltOrRounds = 10;
     
-    let userInfo = await this.usersRepository.findOneBy(
-      {
-        intraId: authDto.intraId
-      })
-      if (userInfo === null) {
-        //회원가입
-        console.log("회원가입");
-        user.intraId = authDto.intraId;
-        user.password = await bcrypt.hash(authDto.password, saltOrRounds);
-        // user.password = authDto.password;
-        user.photoUrl = authDto.photoUrl;
-        user.isOperator = authDto.isOperator;
-        console.log(user)
-        await this.usersRepository.save(user);
+    // todo: Request to dbManager
+    let userInfo = await this.usersRepository.findOneBy({
+      intraId: authDto.intraId
+    })
+    if (userInfo === null) {
+      console.log("[Signing in]");
+      // todo: using repository.create() ?
+      user.intraId = authDto.intraId;
+      user.password = await bcrypt.hash(authDto.password, saltOrRounds);
+      user.photoUrl = authDto.photoUrl;
+      user.isOperator = authDto.isOperator;
+      console.log(user);
+      await this.usersRepository.save(user); // todo: Request to dbManager
       return authDto.intraId;
     }
     else {
       console.log("이미 존재하는 회원");
+
+      // todo: consider
       throw new HttpException('이미 존재하는 회원입니다.', HttpStatus.FORBIDDEN);
     }
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -18,17 +18,21 @@ export class AuthService {
     private usersRepository: Repository<UserInfo>,
   ) {}
 
-
   //42oauth 엑세스 토큰 받아오기
+  /**
+   * 
+   * @param code 42OAuthCode
+   * @returns 42OAuthAccessToken
+   */
   async getOauthToken(code: string) {
     const payload = {
       grant_type: 'authorization_code',
       client_id: 'u-s4t2ud-ffa1eb7dfe8ca1260f9d27ba33051536d23c76cd1ab09f489cb233c7e8e5e065',
       client_secret: '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',
-      redirect_uri: 'https://42mogle.com/auth', //'https://42mogle.com/auth',
+      redirect_uri: 'https://42mogle.com/auth',
       code
     };
-    let ret: string;
+    let retOauthAccessToken: string;
     await this.httpService.axiosRef
       .post('https://api.intra.42.fr/oauth/token', JSON.stringify(payload), {
         headers: {
@@ -36,45 +40,46 @@ export class AuthService {
         },
       })
       .then((res) => {
-        ret = res.data.access_token;
-        console.log("getAccessToken 성공");
+        retOauthAccessToken = res.data.access_token;
+        console.log("get 42OAuth AccessToken 성공");
       })
       .catch((err) => {
-        console.log("getAccessToken 에러");
+        console.log("get 42OAuth AccessToken 실패");
         console.log(err);
-        throw new HttpException('oauth인증 코드를 얻는데 실패하였습니다', HttpStatus.FORBIDDEN);
+        throw new HttpException('42OAuth 인증 코드를 얻는데 실패하였습니다', HttpStatus.FORBIDDEN); // todo: consider
       });
-    return (ret);
+    return (retOauthAccessToken);
   }
 
   //42api로부터 유저 정보 받아오기
   async getUserData(code: string) {
-    let authDto: AuthDto;
-
-    const accessToken = await this.getOauthToken(code);
+    let retAuthDto: AuthDto;
+    const oauthAccessToken = await this.getOauthToken(code);
 
     await this.httpService.axiosRef
       .get('https://api.intra.42.fr/v2/me', {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${oauthAccessToken}`,
           'content-type': 'application/json',
         },
       })
       .then((res) => {
-        authDto =
+        retAuthDto =
         {
           intraId : res.data.login,
-          password: "",
-          photoUrl : res.data.image.link,
+          password: "",                   // todo: consider
+          photoUrl : res.data.image.link, // todo: consider
           isOperator: false
         }
-        console.log("getUserData 성공");
+        console.log("getUserData from 42api 성공");
       })
       .catch((err) => {
-        console.log("getUserData 에러");
+        console.log("getUserData from 42api 에러");
+        
+        // todo: consider
         throw new HttpException('42회원 정보가 존재하지 않습니다.', HttpStatus.FORBIDDEN);
       });
-    return (authDto);
+    return (retAuthDto);
   }
 
   // todo: Rename to createJwtAccessToken()
@@ -96,24 +101,25 @@ export class AuthService {
       else {
         console.log("Wrong password -> 401 UNAUTHORIZED");
         throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.UNAUTHORIZED);
-        //throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.FORBIDDEN);
       }
     }
     else {
       console.log("No user -> 401 UNAUTHORIZED")
       throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.UNAUTHORIZED);
-      //throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.FORBIDDEN);
     }
   }
 
   //회원가입1 oauth인증
   async firstJoin(code: string) {
-    let authDto: AuthDto = await this.getUserData(code);
-    let userInfo = await this.usersRepository.findOneBy({ intraId: authDto.intraId })
+    const authDto: AuthDto = await this.getUserData(code);
 
-    if (userInfo !== null)
-    {
+    // todo: Request to dbManager
+    const userInfo = await this.usersRepository.findOneBy({ intraId: authDto.intraId })
+
+    if (userInfo !== null) {
       console.log("이미 존재하는 회원");
+
+      // todo: consider
       throw new HttpException({errorMessage: "이미 존재하는 회원입니다.",intraId: userInfo.intraId}, HttpStatus.FORBIDDEN);
     }
     return (authDto);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -153,8 +153,8 @@ export class AuthService {
     }
   }
 
-  async DeleteUser(intraId:string)
-  {
+  async deleteUser(intraId:string) {
+    // todo: Request to dbManager
     return (await this.usersRepository.delete({ intraId: intraId }));
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -77,43 +77,33 @@ export class AuthService {
     return (authDto);
   }
 
-  //JWT 액세스 토큰 발행
-  createrAcessToken(authDto: AuthDto)
-  {
-    let intraId: string = authDto.intraId;
-    const payload = { intraId };
+  // todo: Rename to createJwtAccessToken()
+  createrAcessToken(authDto: AuthDto) {
+    const payload = { intraId: authDto.intraId };
     const accessToken = this.jwtService.sign(payload)
     return (accessToken);
   }
 
-  async login(response:Response, authDto:AuthDto) 
-  {
-    /* 
-      디비에 아이디 정보 있는지 확인
-      정보 있을시
-        토큰 발행
-      정보 없을시
-        에러코드 반환 || 에러 반환
-    */
-    const user = new UserInfo();
-
+  async login(response:Response, authDto:AuthDto) {
     let userInfo = await this.usersRepository.findOneBy({ intraId: authDto.intraId });
     if (userInfo !== null) {
       const isMatch = await bcrypt.compare(authDto.password, userInfo.password);
-      console.log(isMatch);
-      if ((userInfo.intraId == authDto.intraId) && isMatch)
-      {
-        console.log("유저 확인 : " + userInfo.intraId);
+      console.log(`isMatch: ${isMatch}`);
+      if ((userInfo.intraId == authDto.intraId) && isMatch) {
+        console.log("User intraId: " + userInfo.intraId);
         return(this.createrAcessToken(authDto));
       }
-      else
-        throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.FORBIDDEN);
-
-      // return (accessToken);
-      // response.cookie("accessToken", accessToken);
+      else {
+        console.log("Wrong password -> 401 UNAUTHORIZED");
+        throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.UNAUTHORIZED);
+        //throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.FORBIDDEN);
+      }
     }
-    else
-      throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.FORBIDDEN);
+    else {
+      console.log("No user -> 401 UNAUTHORIZED")
+      throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.UNAUTHORIZED);
+      //throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.FORBIDDEN);
+    }
   }
 
   //회원가입1 oauth인증

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,6 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+
 export class AuthDto {
+    @ApiProperty()
     intraId : string;
+
+    @ApiProperty()
     password : string;
+
+    @ApiProperty()
     photoUrl : string;
+
+    @ApiProperty()
     isOperator : boolean;
 }

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,15 +1,35 @@
 import { ApiProperty } from "@nestjs/swagger";
 
+// todo: Rename to SignInDto ?
 export class AuthDto {
-    @ApiProperty({ type: String })
+    @ApiProperty({
+        type: String,
+        example: 'mgo',
+        description: '사용자 인트라 아이디',
+        required: true
+    })
     intraId : string;
 
-    @ApiProperty({ type: String })
+    @ApiProperty({
+        type: String,
+        example: 'q1w2e3r4T%',
+        description: '비밀번호',
+        required: true
+    })
     password : string;
 
-    @ApiProperty({ type: String })
+    @ApiProperty({
+        type: String,   
+        description: '사진 URL',
+        required: false
+    })
     photoUrl : string;
 
-    @ApiProperty({ type: Boolean })
+    @ApiProperty({
+        type: Boolean,
+        example: false,
+        description: "오퍼레이터 권한 유무",
+        required: true
+    })
     isOperator : boolean;
 }

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,15 +1,15 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class AuthDto {
-    @ApiProperty()
+    @ApiProperty({ type: String })
     intraId : string;
 
-    @ApiProperty()
+    @ApiProperty({ type: String })
     password : string;
 
-    @ApiProperty()
+    @ApiProperty({ type: String })
     photoUrl : string;
 
-    @ApiProperty()
+    @ApiProperty({ type: Boolean })
     isOperator : boolean;
 }

--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -4,7 +4,7 @@ export const typeORMConfig : TypeOrmModuleOptions = {
 	type: 'postgres',
 	host: 'localhost',
 	port: 5432,
-	username: 'postgres',
+	username: 'mgo',	// info: 클러스터 맥에서 homebrew로 설치한 DB 사용시 등록된 user명으로 사용 (ex. mgo)
 	password: 'postgres',
 	database: 'test',
 	entities: [

--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -4,7 +4,7 @@ export const typeORMConfig : TypeOrmModuleOptions = {
 	type: 'postgres',
 	host: 'localhost',
 	port: 5432,
-	username: 'mgo',	// info: 클러스터 맥에서 homebrew로 설치한 DB 사용시 등록된 user명으로 사용 (ex. mgo)
+	username: 'postgres',	// info: 클러스터 맥에서 homebrew로 설치한 DB 사용시 등록된 user명으로 사용 (ex. mgo)
 	password: 'postgres',
 	database: 'test',
 	entities: [

--- a/src/dbmanager/dbmanager.controller.ts
+++ b/src/dbmanager/dbmanager.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { DbmanagerService } from './dbmanager.service';
-import { CreateUserDto } from './dto/create-user.dto';
+//import { CreateUserDto } from './dto/create-user.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { ApiTags } from '@nestjs/swagger';
+import { CreateUserDto } from 'src/attendance/dto/create-user.dto';
 
 @ApiTags('DbManager')
 @Controller('dbmanager')

--- a/src/dbmanager/dbmanager.controller.ts
+++ b/src/dbmanager/dbmanager.controller.ts
@@ -4,7 +4,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { ApiTags } from '@nestjs/swagger';
 
-@ApiTags('dbmanager')
+@ApiTags('DbManager')
 @Controller('dbmanager')
 export class DbmanagerController {
 	constructor(private readonly dbmanagerService: DbmanagerService) { }

--- a/src/dbmanager/dbmanager.module.ts
+++ b/src/dbmanager/dbmanager.module.ts
@@ -8,6 +8,7 @@ import { DayInfo } from './entities/day_info.entity';
 import { Attendance } from './entities/attendance.entity';
 import { MonthlyUsers } from './entities/monthly_users.entity';
 
+// todo: Rename to DbManager
 @Module({
   imports: [
     TypeOrmModule.forFeature(

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -1,18 +1,19 @@
 import { All, BadRequestException, GatewayTimeoutException, Injectable, NotFoundException } from '@nestjs/common';
-import { CreateUserDto } from './dto/create-user.dto';
+//import { CreateUserDto } from './dto/create-user.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
 import { Repository, ReturningStatementNotSupportedError } from 'typeorm';
 import { Attendance } from './entities/attendance.entity';
 import { Cron, Interval } from '@nestjs/schedule';
 import { MonthInfo } from './entities/month_info.entity';
-import { CreateAttendanceDto } from './dto/create-attendance.dto';
+import { CreateAttendanceDto } from '../attendance/dto/create-attendance.dto';
 import { DayInfo } from './entities/day_info.entity';
 import { userInfo } from 'os';
 import * as request from 'supertest';
 import { MonthlyUsers } from './entities/monthly_users.entity';
 import { UpdateUserAttendanceDto } from '../operator/dto/updateUserAttendance.dto';
 import { create } from 'domain';
+import { CreateUserDto } from 'src/attendance/dto/create-user.dto';
 
 @Injectable()
 export class DbmanagerService {
@@ -110,18 +111,17 @@ export class DbmanagerService {
 	}
 
 
-	async getDayInfo() {
+	async getTodayInfo() {
 		const now = new Date();
 		const day = now.getDate();
 		const month = now.getMonth() + 1;
 		const year = now.getFullYear();
-		const monthInfo: MonthInfo = await this.getMonthInfo(month + 1, year);
+		const monthInfo: MonthInfo = await this.getMonthInfo(month, year);
 		return await this.dayInfoRepository.findOneBy({ day, monthInfo })
 	}
 
-	async setToDayWord(toDayWord: string) {
-		const now = new Date();
-		const dayInfo = await this.getDayInfo();
+	async setTodayWord(toDayWord: string) {
+		const dayInfo = await this.getTodayInfo();
 		dayInfo.todayWord = toDayWord;
 		await this.dayInfoRepository.save(dayInfo)
 	}
@@ -129,7 +129,7 @@ export class DbmanagerService {
 	async attendanceRegistration(attendinfo: CreateAttendanceDto) {
 		const now = new Date();
 		const userInfo: UserInfo = await this.getUserInfo(attendinfo.intraId);
-		const dayInfo: DayInfo = await this.getDayInfo();
+		const dayInfo: DayInfo = await this.getTodayInfo();
 		const attendanceinfo = this.attendanceRepository.create(
 			{
 				timelog: now,
@@ -141,11 +141,11 @@ export class DbmanagerService {
 	}
 
 	async getAttendanceUserInfo(userInfo: UserInfo, dayInfo: DayInfo): Promise<Attendance> {
-		return await this.attendanceRepository.findOneBy({ userInfo, dayInfo }); // using userInfo, dayInfo
+		return await this.attendanceRepository.findOneBy({ userInfo, dayInfo });
 	}
 
-	async getToDayWord(): Promise<string> {
-		const found: DayInfo = await this.getDayInfo();
+	async getTodayWord(): Promise<string> {
+		const found: DayInfo = await this.getTodayInfo();
 		const ret = found.todayWord;
 		console.log("todayWord in server:", ret);
 		return ret;
@@ -213,6 +213,7 @@ export class DbmanagerService {
 		if (!this.isWeekend())
 		{
 			monthlyuser.attendanceCount += 1;
+			// todo: save랑 update 둘 중에 하나만 하기
 			this.monthlyUsersRepository.save(monthlyuser);
 			this.monthlyUsersRepository.update(monthlyuser.id, {
 				attendanceCount: monthlyuser.attendanceCount,

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -42,6 +42,7 @@ export class DbmanagerService {
 		return this.usersRepository.save(user);
 	}
 
+	// todo: Remove
 	async findAll(): Promise<UserInfo[]> {
 		return await this.usersRepository.find();
 	}

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -62,10 +62,11 @@ export class DbmanagerService {
 		const now = new Date();
 		const year = now.getFullYear();
 		const month = now.getMonth() + 1;
-		const totalAttendance = new Date(year, month, 0).getDate(); //bolck
-		const found = await this.monthInfoRepository.findOne({ where: { year, month } });
-		if (found)
+		const totalAttendance = new Date(year, month, 0).getDate(); // todo: consider what 0 means
+		const foundThhisMonthInfo = await this.monthInfoRepository.findOne({ where: { year, month } });
+		if (foundThhisMonthInfo) {
 			throw "이번달 데이터가 이미 있습니다.";
+		}
 		const monthInfo = this.monthInfoRepository.create({
 			year: year,
 			month: month,

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -245,21 +245,21 @@ export class DbmanagerService {
 		return await this.monthlyUsersRepository.findBy({userInfo: allUserInfo, monthInfo});
 	}
 
-	updateAttendanceCountThisMonth(monthlyuser: MonthlyUsers) {
+	async updateAttendanceCountThisMonth(monthlyuser: MonthlyUsers) {
 		monthlyuser.attendanceCount += 1;
-		this.monthlyUsersRepository.update(monthlyuser.id, {
+		await this.monthlyUsersRepository.update(monthlyuser.id, {
 			attendanceCount: monthlyuser.attendanceCount
 		})
 	}
 
-	updateAtendanceInfo(userInfo: UserInfo, dayInfo: DayInfo, InfoDto: UpdateUserAttendanceDto) {
+	async updateAtendanceInfo(userInfo: UserInfo, dayInfo: DayInfo, InfoDto: UpdateUserAttendanceDto) {
 		const timelog = new Date(InfoDto.year, InfoDto.month - 1, InfoDto.day, 8, 30, 0);
 		const userAttendance = this.attendanceRepository.create({
 			userInfo,
 			dayInfo,
 			timelog,
 		});
-		this.attendanceRepository.save(userAttendance);
+		await this.attendanceRepository.save(userAttendance);
 	}
 
 	changeIsPerfect(monthlyUserInfo: MonthlyUsers, status: boolean) {

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -241,6 +241,7 @@ export class DbmanagerService {
 		return await this.usersRepository.find();
 	}
 
+	// todo: consider for only using MonthInfo
 	async getAllMonthlyUser(allUserInfo: UserInfo[], monthInfo: MonthInfo) {
 		return await this.monthlyUsersRepository.findBy({userInfo: allUserInfo, monthInfo});
 	}

--- a/src/dbmanager/dto/create-attendance.dto.ts
+++ b/src/dbmanager/dto/create-attendance.dto.ts
@@ -1,3 +1,5 @@
+
+// dto가 dbmanager, attendance에 다 있는데 둘 중에 뭐가 진짜임?
 export class CreateAttendanceDto {
 	intraId: string;
 	todayWord: string;

--- a/src/dbmanager/dto/create-attendance.dto.ts
+++ b/src/dbmanager/dto/create-attendance.dto.ts
@@ -1,6 +1,0 @@
-
-// dto가 dbmanager, attendance에 다 있는데 둘 중에 뭐가 진짜임?
-export class CreateAttendanceDto {
-	intraId: string;
-	todayWord: string;
-}

--- a/src/dbmanager/dto/create-user.dto.ts
+++ b/src/dbmanager/dto/create-user.dto.ts
@@ -1,4 +1,0 @@
-export class CreateUserDto {
-	intraId: string;
-	password: string;
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,13 +5,18 @@ import * as fs from 'fs';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  // const httpsOptions = {
-  //   key: fs.readFileSync('/etc/letsencrypt/archive/42mogle.com/privkey1.pem'),
-  //   cert: fs.readFileSync('/etc/letsencrypt/archive/42mogle.com/fullchain1.pem'),
-  // };
-  // const app = await NestFactory.create(AppModule, {
-  //   httpsOptions,
-  // });
+
+  /* When using ssl for https
+
+  const httpsOptions = {
+    key: fs.readFileSync('/etc/letsencrypt/archive/42mogle.com/privkey1.pem'),
+    cert: fs.readFileSync('/etc/letsencrypt/archive/42mogle.com/fullchain1.pem'),
+  };
+  const app = await NestFactory.create(AppModule, {
+    httpsOptions,
+  });
+
+  */
 
   // Setting Swagger
   const config = new DocumentBuilder()
@@ -28,6 +33,7 @@ async function bootstrap() {
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   });
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,16 @@ async function bootstrap() {
     .setTitle('42mogle API docs')
     .setDescription('API description')
     .setVersion('0.1')
+    // Setting JWT token
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'JWT',
+        in: 'header',
+      },
+      'access-token',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);

--- a/src/operator/dto/today_Word.dto.ts
+++ b/src/operator/dto/today_Word.dto.ts
@@ -1,4 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
 export class SetTodayWordDto {
+	@ApiProperty()
 	intraId: string;
+
+	@ApiProperty()
 	todayWord: string;
 }

--- a/src/operator/dto/updateUserAttendance.dto.ts
+++ b/src/operator/dto/updateUserAttendance.dto.ts
@@ -1,7 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+
 export class UpdateUserAttendanceDto {
+	@ApiProperty()
 	passWord: string;
+
+	@ApiProperty()
 	intraId: string;
+
+	@ApiProperty()
 	year: number;
+
+	@ApiProperty()
 	month: number;
+
+	@ApiProperty()
 	day: number;
 }

--- a/src/operator/operator.controller.ts
+++ b/src/operator/operator.controller.ts
@@ -5,7 +5,7 @@ import { UpdateUserAttendanceDto } from './dto/updateUserAttendance.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { ApiTags } from '@nestjs/swagger';
 
-@ApiTags('operator')
+@ApiTags('Operator')
 @Controller('operator')
 export class OperatorController {
 	constructor(private readonly operatorService: OperatorService) {}

--- a/src/operator/operator.controller.ts
+++ b/src/operator/operator.controller.ts
@@ -54,6 +54,16 @@ export class OperatorController {
 	 */
 	@Post("/update/users/attendanceInfo") // 모든 유저의 출석정보를 업데이트함 //크론으로 대체
 	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
+	@ApiOperation({summary: 'update all monthly users attendance info'})
+	@ApiResponse({
+		status: 201, 
+		description: 'Success', 
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+	})
 	updateAllusersAttendanceInfo() {
 		this.operatorService.updateUsersAttendanceInfo();
 	}
@@ -63,6 +73,16 @@ export class OperatorController {
 	 */
 	@Post("/update/currentAttendanceCount") // 현재까지 개근 가능한 출석일수를 갱신 //크론으로 대체
 	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
+	@ApiOperation({summary: 'update month currrent attendance count'})
+	@ApiResponse({
+		status: 201, 
+		description: 'Success', 
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+	})
 	updateCurrentAttendanceCount() {
 		this.operatorService.updateCurrentCount();
 	}

--- a/src/operator/operator.controller.ts
+++ b/src/operator/operator.controller.ts
@@ -3,33 +3,66 @@ import { OperatorService } from './operator.service';
 import { SetTodayWordDto } from './dto/today_Word.dto';
 import { UpdateUserAttendanceDto } from './dto/updateUserAttendance.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Operator')
 @Controller('operator')
 export class OperatorController {
 	constructor(private readonly operatorService: OperatorService) {}
 	
-	@UseGuards(JwtAuthGuard)
+	/**
+	 * PATCH /operator/setTodayWord
+	 */
 	@Patch("/setTodayWord") // 오늘의 단어 설정
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
+	@ApiOperation({summary: 'set today word'})
+	@ApiResponse({
+		status: 201, // todo: consider
+		description: 'Success', 
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+	})
 	settodayword(@Body() setTodayWordDto: SetTodayWordDto) {
 		this.operatorService.setTodayWord(setTodayWordDto);
 	}
 
-	@UseGuards(JwtAuthGuard)
+	/**
+	 * POST /operator/update/user/attendance
+	 */
 	@Post("/update/user/attendance") // 유저의 출석데이터를 임의로 추가함
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
+	@ApiOperation({summary: 'add a user attendance'})
+	@ApiResponse({
+		status: 201, 
+		description: 'Success', 
+		// todo: Set type using dto
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+	})
 	updateUserAttendance(@Body() updateUserAttendanceDto: UpdateUserAttendanceDto) {
 		return this.operatorService.updateUserAttendance(updateUserAttendanceDto);
 	}
 
-	@UseGuards(JwtAuthGuard)
+	/**
+	 * POST /operator/update/users/attendanceInfo
+	 */
 	@Post("/update/users/attendanceInfo") // 모든 유저의 출석정보를 업데이트함 //크론으로 대체
+	@UseGuards(JwtAuthGuard)
 	updateAllusersAttendanceInfo() {
 		this.operatorService.updateUsersAttendanceInfo();
 	}
 
-	@UseGuards(JwtAuthGuard)
+	/**
+	 * POST /operator/update/currentAttendanceCount
+	 */
 	@Post("/update/currentAttendanceCount") // 현재까지 개근 가능한 출석일수를 갱신 //크론으로 대체
+	@UseGuards(JwtAuthGuard)
 	updateCurrentAttendanceCount() {
 		this.operatorService.updateCurrentCount();
 	}

--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -68,7 +68,6 @@ export class OperatorService {
 	}
 
 	updatePerfectStatus(monthlyUserInfo: MonthlyUsers, currentAttendance: number) {
-		console.log(monthlyUserInfo.attendanceCount, currentAttendance);
 		if (monthlyUserInfo.attendanceCount < currentAttendance && monthlyUserInfo.isPerfect === true)
 			this.dbmanagerService.changeIsPerfect(monthlyUserInfo, false);
 		else if (monthlyUserInfo.attendanceCount === currentAttendance && monthlyUserInfo.isPerfect === false)
@@ -78,6 +77,8 @@ export class OperatorService {
 	@Cron('0 0 1 * * 0-6')
 	async updateCurrentCount() {
 		const type: number = this.dbmanagerService.getTodayType();
+		// 0: 일요일
+		// 6: 토요일
 		if (type !== 0 && type !== 6)
 			this.dbmanagerService.updateThisMonthCurrentCount();
 	}

--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -15,7 +15,7 @@ export class OperatorService {
 
 	setTodayWord(setTodayWordDto: SetTodayWordDto) {
 		if (this.dbmanagerService.isAdmin(setTodayWordDto.intraId)) {
-			this.dbmanagerService.setToDayWord(setTodayWordDto.todayWord);
+			this.dbmanagerService.setTodayWord(setTodayWordDto.todayWord);
 			return "오늘의 단어 설정 성공"
 		}
 		else {
@@ -58,11 +58,11 @@ export class OperatorService {
 		const monthInfo: MonthInfo = await this.dbmanagerService.getThisMonthInfo();
 		const AllmonthlyUser: MonthlyUsers[] = await this.dbmanagerService.getAllMonthlyUser(allUsersInfo, monthInfo);
 		AllmonthlyUser.forEach((user) => {
-			this.statusUpdate(user, monthInfo.currentAttendance);
+			this.updatePerfectStatus(user, monthInfo.currentAttendance);
 		})
 	}
 
-	statusUpdate(monthlyUserInfo: MonthlyUsers, currentAttendance: number) {
+	updatePerfectStatus(monthlyUserInfo: MonthlyUsers, currentAttendance: number) {
 		console.log(monthlyUserInfo.attendanceCount, currentAttendance);
 		if (monthlyUserInfo.attendanceCount < currentAttendance && monthlyUserInfo.isPerfect === true)
 			this.dbmanagerService.changeIsPerfect(monthlyUserInfo, false);

--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -24,27 +24,32 @@ export class OperatorService {
 	}
 
 	async updateUserAttendance(updateUserAttendanceDto: UpdateUserAttendanceDto): Promise<string> {
-		if (updateUserAttendanceDto.passWord !== "42MogleOperator")
+		if (updateUserAttendanceDto.passWord !== "42MogleOperator") {
 			return "권한이 없습니다."
+		}
 		const userInfo: UserInfo = await this.dbmanagerService.getUserInfo(updateUserAttendanceDto.intraId);
 		const monthInfo: MonthInfo = await this.dbmanagerService.getSpecificMonthInfo(
 			updateUserAttendanceDto.year,
 			updateUserAttendanceDto.month
-		)
+		);
 		if (!monthInfo) {
-			return "잘못된 입력입니다."
+			return "잘못된 입력입니다: monthInfo"
 		}
 		const dayInfo: DayInfo = await this.dbmanagerService.getSpecificDayInfo(
 			monthInfo,
 			updateUserAttendanceDto.day
-			);
-		if (!dayInfo || !UserInfo)
-			return "잘못된 입력 입니다.";
-		const attendanceInfo = await this.dbmanagerService.getAttendanceUserInfo(userInfo, dayInfo)
+		);
+		if (!dayInfo) {
+			return "잘못된 입력입니다: dayInfo";
+		}
+		else if (!userInfo) {
+			return "잘못된 입력입니다: userInfo";
+		}
+		const attendanceInfo = await this.dbmanagerService.getAttendanceUserInfo(userInfo, dayInfo);
 		if (!attendanceInfo) {
-			this.dbmanagerService.updateAtendanceInfo(userInfo, dayInfo, updateUserAttendanceDto);
+			await this.dbmanagerService.updateAtendanceInfo(userInfo, dayInfo, updateUserAttendanceDto);
 			const monthlyUserInfo : MonthlyUsers = await this.dbmanagerService.getSpecificMonthlyuserInfo(monthInfo, userInfo);
-			this.dbmanagerService.updateAttendanceCountThisMonth(monthlyUserInfo)
+			await this.dbmanagerService.updateAttendanceCountThisMonth(monthlyUserInfo)
 			return "출석체크 완료";
 		}
 		else {

--- a/src/statistic/statistic.controller.ts
+++ b/src/statistic/statistic.controller.ts
@@ -9,6 +9,9 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 export class StatisticController {
 	constructor(private readonly statisticService: StatisticService) {}
 
+	/**
+	 * GET /statistic/{intraId}/userAttendanceList
+	 */
 	@Get("/:intraId/userAttendanceList")
 	@UseGuards(JwtAuthGuard)
 	@ApiBearerAuth('access-token')
@@ -38,11 +41,34 @@ export class StatisticController {
 		return await this.statisticService.getAttendanceList(intraId);
 	}
 
-	//출석 일수
-	//개근 여부
+	/**
+	 * GET /statistic/{intraId}/userAttendanceState
+	 */
+	@Get(":intraId/userAttendanceState")
 	@UseGuards(JwtAuthGuard)
-	@Get(":intraId/userAttendanceState") //메인 화면에 띄워줄 출석인수와 개근여부를 반환
+	@ApiBearerAuth('access-token')
+	@ApiOperation({
+		summary: 'get the user attendance state',
+		description: '유저 home 화면에 띄워줄 출석일수와 개근여부를 반환'
+	})
+	@ApiParam({
+		name: 'intraId',
+		type: String,
+	})
+	@ApiResponse({
+		status: 200, 
+		description: 'Success', 
+		// todo: type: DTO로 정의하기
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard: No JWT access-token)'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
 	async getUserAttendanceState(@Param("intraId") intraId: string) {
-		return this.statisticService.getUserMonthStatus(intraId);
+		return await this.statisticService.getUserMonthStatus(intraId);
 	}
 }

--- a/src/statistic/statistic.controller.ts
+++ b/src/statistic/statistic.controller.ts
@@ -2,17 +2,39 @@ import { ConsoleLogger, Controller, Get, Param, UseGuards } from '@nestjs/common
 import { Attendance } from 'src/dbmanager/entities/attendance.entity';
 import { StatisticService } from './statistic.service';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Statistic')
 @Controller('statistic')
 export class StatisticController {
 	constructor(private readonly statisticService: StatisticService) {}
 
-	@UseGuards(JwtAuthGuard)
 	@Get("/:intraId/userAttendanceList")
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
+	@ApiOperation({
+		summary: 'get the user attendance list',
+		description: '유저 출석 정보 리스트 요청'
+	})
+	@ApiParam({
+		name: 'intraId',
+		type: String,
+	})
+	@ApiResponse({
+		status: 200, 
+		description: 'Success', 
+		// todo: type: Attendance list
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard: No JWT access-token)'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
 	async getUserAttendanceList(@Param("intraId") intraId: string): Promise<Attendance[]> {
-		console.log("왔니?");
+		console.log("[GET /statistic/{intraId}/userAttendanceList] requested.");
 		return await this.statisticService.getAttendanceList(intraId);
 	}
 

--- a/src/statistic/statistic.controller.ts
+++ b/src/statistic/statistic.controller.ts
@@ -4,7 +4,7 @@ import { StatisticService } from './statistic.service';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { ApiTags } from '@nestjs/swagger';
 
-@ApiTags('statistic')
+@ApiTags('Statistic')
 @Controller('statistic')
 export class StatisticController {
 	constructor(private readonly statisticService: StatisticService) {}

--- a/src/user/dto/user-info.dto.ts
+++ b/src/user/dto/user-info.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UserInfoDto {
+    @ApiProperty({ type: 'string' })
+    intraId : string;
+
+    @ApiProperty({ type: 'boolean' })
+    isOperator : boolean;
+
+    @ApiProperty({ type: 'string' })
+    photoUrl : string;
+}

--- a/src/user/dto/user-info.dto.ts
+++ b/src/user/dto/user-info.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class UserInfoDto {
-    @ApiProperty({ type: 'string' })
+    @ApiProperty({ type: String })
     intraId : string;
 
-    @ApiProperty({ type: 'boolean' })
+    @ApiProperty({ type: Boolean })
     isOperator : boolean;
 
-    @ApiProperty({ type: 'string' })
+    @ApiProperty({ type: String })
     photoUrl : string;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -45,6 +45,7 @@ export class UserController {
 	// GET /user //현재는 사용되지 않음
 	@ApiOperation({summary: 'get all users'})
 	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
 	@Get('/')
 	getAllUser(): Promise<UserInfo[]> {
 		return this.userService.findAll();

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -2,7 +2,7 @@ import { UserService } from './user.service';
 import { UserInfoDto } from './dto/user-info.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
-import { ApiParam, ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger'
+import { ApiParam, ApiOperation, ApiTags, ApiResponse, ApiCreatedResponse, ApiBearerAuth } from '@nestjs/swagger'
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 
 @ApiTags('User')
@@ -14,7 +14,12 @@ export class UserController {
 
 	// GET /user/{intraId}
 	@Get('/:intraId')
-	@ApiOperation({summary: 'get the user information'})
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token') // setting JWT token key
+	@ApiOperation({
+		summary: 'get the user information',
+		description: '유저 정보 요청 API'
+	})
 	@ApiParam({
 		name: 'intraId',
 		type: String,
@@ -26,13 +31,12 @@ export class UserController {
 	})
 	@ApiResponse({
 		status: 401,
-		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard: No JWT access-token)'
 	})
 	@ApiResponse({
 		status: 403,
 		description: 'Forbidden'
 	})
-	@UseGuards(JwtAuthGuard)
 	async getUserInfo(@Param('intraId') intraId: string): Promise<UserInfoDto> {
 		return await this.userService.getUserInfoByIntraId(intraId);
 	}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,45 +1,48 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
-import { stringify } from 'querystring';
-import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
 import { UserService } from './user.service';
-import { ApiParam, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
-import { CreateAttendanceDto } from 'src/dbmanager/dto/create-attendance.dto';
-import { Certificate } from 'crypto';
+import { UserInfoDto } from './dto/user-info.dto';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
+import { ApiParam, ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger'
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 
-// 일단 유저 출석, 개근 수치들은 Statistic module에서 처리하는게 맞는 것 같습니다!
-// 유저 정보 관련 -> UserInfo 모듈
-// 출석 로직 관련 -> Attendance 모듈
-// 출석, 개근 수치 관련 -> Statistic 모듈
-// 오퍼레이터 기능 -> Operator 모듈
-
-@ApiTags('user')
+@ApiTags('User')
 @Controller('user')
 export class UserController {
-	constructor(private userService: UserService) {
+	constructor(private readonly userService: UserService) {
 		this.userService = userService;
 	}
 
+	// GET /user/{intraId}
+	@Get('/:intraId')
+	@ApiOperation({summary: 'get the user information'})
+	@ApiParam({
+		name: 'intraId',
+		type: String,
+	})
+	@ApiResponse({
+		status: 200, 
+		description: 'Success', 
+		type: UserInfoDto,
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
+	@UseGuards(JwtAuthGuard)
+	async getUserInfo(@Param('intraId') intraId: string): Promise<UserInfoDto> {
+		return await this.userService.getUserInfoByIntraId(intraId);
+	}
+
+	// todo: Remove
 	// GET /user //현재는 사용되지 않음
 	@ApiOperation({summary: 'get all users'})
 	@UseGuards(JwtAuthGuard)
 	@Get('/')
 	getAllUser(): Promise<UserInfo[]> {
 		return this.userService.findAll();
-	}
-
-	// GET /user/:intraId
-	@ApiOperation({summary: 'get the user having the intraId'})
-	@ApiParam({
-		name: 'intraId',
-		type: 'string',
-	})
-	@ApiOkResponse({
-		description: 'Success'
-	})
-	@UseGuards(JwtAuthGuard)
-	@Get('/:intraId') // 유저의 정보 1.인트라아이디 2.오퍼레이터 여부 3. photoUrl
-	getUserInfo(@Param('intraId') intraId: string) {
-		return this.userService.getUserInfoByIntraId(intraId);
 	}
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -15,6 +15,8 @@ export class UserService {
 
 	async getUserInfoByIntraId(inputtedintraId: string): Promise<UserInfoDto> {
 		const user: UserInfo  = await this.dbmanagerService.getUserInfo(inputtedintraId);
+		// todo: user를 못 찾으면 따로 에러처리 유무 조사하고 결정하기
+		
 		const userInfoDto: UserInfoDto = {
 			intraId: user.intraId,
 			isOperator: user.isOperator,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -4,6 +4,7 @@ import { CreateAttendanceDto } from '../dbmanager/dto/create-attendance.dto';
 import { AttendanceService } from '../attendance/attendance.service';
 import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
 import { Attendance } from '../dbmanager/entities/attendance.entity';
+import { UserInfoDto } from './dto/user-info.dto';
 
 @Injectable()
 export class UserService {
@@ -12,12 +13,14 @@ export class UserService {
 	@Inject(AttendanceService)
 	private readonly attendanceService: AttendanceService;
 
-	async getUserInfoByIntraId(inputtedintraId: string) {
+	async getUserInfoByIntraId(inputtedintraId: string): Promise<UserInfoDto> {
 		const user: UserInfo  = await this.dbmanagerService.getUserInfo(inputtedintraId);
-		const intraId: string = user.intraId;
-		const isOperator: boolean = user.isOperator;
-		const PhotoUrl: string = user.photoUrl;
-		return { intraId, isOperator, PhotoUrl };
+		const userInfoDto: UserInfoDto = {
+			intraId: user.intraId,
+			isOperator: user.isOperator,
+			photoUrl: user.photoUrl
+		};
+		return userInfoDto;
 	}
 
 	async findAll(): Promise<UserInfo[]> {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -25,6 +25,7 @@ export class UserService {
 		return userInfoDto;
 	}
 
+	// todo: Remove
 	async findAll(): Promise<UserInfo[]> {
 		const ret = await this.dbmanagerService.findAll();
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { DbmanagerService } from 'src/dbmanager/dbmanager.service';
-import { CreateAttendanceDto } from '../dbmanager/dto/create-attendance.dto';
+import { CreateAttendanceDto } from '../attendance/dto/create-attendance.dto';
 import { AttendanceService } from '../attendance/attendance.service';
 import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
 import { Attendance } from '../dbmanager/entities/attendance.entity';
@@ -34,12 +34,13 @@ export class UserService {
 		return ret;
 	}
 
+	// 이거 attendance에도 있음. 확인 필요.
  	async AttendanceCertification(attendanceinfo: CreateAttendanceDto): Promise<Attendance> {
-		const toDayWord: string = await this.dbmanagerService.getToDayWord();
-		if (await this.attendanceService.isAttendance(attendanceinfo.intraId)) {
+		const todayWord: string = await this.dbmanagerService.getTodayWord();
+		if (await this.attendanceService.haveAttendedToday(attendanceinfo.intraId)) {
 			throw new NotFoundException("이미 출석체크 했습니다.");
 		}
-		else if (attendanceinfo.todayWord !== toDayWord) {
+		else if (attendanceinfo.todayWord !== todayWord) {
 			throw new NotFoundException("오늘의 단어가 다릅니다!");
 		}
 		return this.dbmanagerService.attendanceRegistration(attendanceinfo);


### PR DESCRIPTION
Swagger로 API 문서 만들면서 모든 모듈에 있는 코드를 읽고 확인해봤습니다.
코드를 확인하면서 조금씩 리팩토링도 진행했습니다.

- Swagger API 문서화 관련
    1. Dbmanager와 auth의 test용 api를 제외한 모든 api에 swagger decorator를 추가했습니다.
    2. Swagger 설정에 addBearerAuth()를 추가하고 API 앞에 @ApiBearerAuth('access-token')를 붙이면 Swagger 문서에서도 JWT 인증 토큰을 넣어서 요청을 보낼 수 있습니다.
    3. DTO에 ApiProperty()를 추가해서 문서에 속성들을 나타내도록 했습니다.
- Refactoring 관련
    1. Auth의 login 부분에서 유저의 아이디가 없거나 비밀번호가 다르면 403(not found) 에러코드를 보내는 대신 401(unauthorized) 에러코드를 바꾸도록 수정했습니다.
        - 이유는 로그인 부분에서 실패하면 인증과 관련해서 실패했기 때문입니다. 관련 링크는 아래입니다.
            - https://stackoverflow.com/questions/32752578/whats-the-appropriate-http-status-code-to-return-if-a-user-tries-logging-in-wit
    2. object를 반환하는 경우에 DTO를 정의해서 수정한 부분이 있습니다. 아직 모든 부분을 DTO로 바꾸지 않아서 추후에 개선이 필요합니다.

확인부탁드립니다.