### PR TITLE
Fix/first join and second join API for security

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -93,20 +93,7 @@ export class AuthController {
    })
    logout(@Res() response:Response) {
      console.log(`[ POST /serverAuth/logout ] requested.`);
-     /** 
-      * When using cookie (saving accessToken in cookie), run below code.
-      */
-     // response.cookie("accessToken","",
-     // {
-     //   httpOnly: true,
-     //   maxAge: 0
-     // })
- 
-     /** 
-      * When using local storage, the front-end removes the accessToken.
-      */
- 
-     response.send({message:'로그아웃'});
+     response.send({ message:'로그아웃' });
      return ;
    } 
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -16,60 +16,7 @@ export class AuthController {
     ) {}
 
   /**
-   * POST /serverAuth/login
-   */
-  @Post('login')
-	@ApiOperation({summary: 'request user login'})
-	@ApiResponse({
-		status: 201, 
-		description: 'Success'
-	})
-	@ApiResponse({
-		status: 401,
-		description: 'Unauthorized'
-	})
-  async login(@Res() response: Response, @Body() authDto: AuthDto) {
-    console.log("[ POST /serverAuth/login ] requested.");
-    console.log(`authDto.intraId: [${authDto.intraId}]`);
-    const accessToken = await this.authService.login(response, authDto);
-    response.send({ accessToken });
-    return ;
-  }
-
-  /**
-   * POST /serverAuth/logout
-   */
-  @Post('logout')
-  @ApiOperation({summary: 'request user logout'})
-	@ApiResponse({
-		status: 201, 
-		description: 'Success'
-	})
-	@ApiResponse({
-		status: 403,
-		description: 'Forbidden'
-	})
-  logout(@Res() response:Response) {
-    console.log(`[ POST /serverAuth/logout ] requested.`);
-    /** 
-     * When using cookie (saving accessToken in cookie), run below code.
-     */
-    // response.cookie("accessToken","",
-    // {
-    //   httpOnly: true,
-    //   maxAge: 0
-    // })
-
-    /** 
-     * When using local storage, the front-end removes the accessToken.
-     */
-
-    response.send({message:'로그아웃'});
-    return ;
-  }
-
-  /**
-   * GET /serverAuth/firstJoin?code=
+   * GET /serverAuth/firstJoin?code=${code}
    */
   @Get('firstJoin')
   @ApiOperation({summary: 'get a user info from 42OAuth'})
@@ -110,42 +57,58 @@ export class AuthController {
     return(await this.authService.secondJoin(authDto));
   }
 
-  // todo: Remove
-  // test
-  @Get('test0')
-  @ApiOperation({summary: 'for testing'})
-  test0()
-  {
-    console.log("hello");
-    return("test0")
-  }
-  
-  // todo: Remove
-  // test
-  @Post('test')
-	@ApiCreatedResponse({
-		description: '테스트',
-		schema: {
-			example: {
-				intraId: 'mgo',
-				isOperator: true,
-				photoUrl: 'https://awesome.photo'
-			}
-		}
-	})
-  @ApiOperation({summary: 'for testing'})
-  async test(@Body() authDto: AuthDto)
-  {
-    // response.cookie("accessToken", this.authService.createrAcessToken(authDto),
-    // {
-    //   httpOnly: true,
-    //   secure: true,
-    //   sameSite: "none",
-    //   maxAge: 24 * 60 * 60 * 1000 //1 day
-    // })
-    // return(response.send({message:'로그인 성공'}));
-    return (this.authService.createrAcessToken(authDto));
-  }
+  /**
+   * POST /serverAuth/login
+   */
+   @Post('login')
+   @ApiOperation({summary: 'request user login'})
+   @ApiResponse({
+     status: 201, 
+     description: 'Success'
+   })
+   @ApiResponse({
+     status: 401,
+     description: 'Unauthorized'
+   })
+   async login(@Res() response: Response, @Body() authDto: AuthDto) {
+     console.log("[ POST /serverAuth/login ] requested.");
+     console.log(`authDto.intraId: [${authDto.intraId}]`);
+     const accessToken = await this.authService.login(authDto);
+     response.send({ accessToken });
+     return ;
+   }
+ 
+   /**
+    * POST /serverAuth/logout
+    */
+   @Post('logout')
+   @ApiOperation({summary: 'request user logout'})
+   @ApiResponse({
+     status: 201, 
+     description: 'Success'
+   })
+   @ApiResponse({
+     status: 403,
+     description: 'Forbidden'
+   })
+   logout(@Res() response:Response) {
+     console.log(`[ POST /serverAuth/logout ] requested.`);
+     /** 
+      * When using cookie (saving accessToken in cookie), run below code.
+      */
+     // response.cookie("accessToken","",
+     // {
+     //   httpOnly: true,
+     //   maxAge: 0
+     // })
+ 
+     /** 
+      * When using local storage, the front-end removes the accessToken.
+      */
+ 
+     response.send({message:'로그아웃'});
+     return ;
+   } 
 
   // todo: Remove
   // test

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -110,19 +110,6 @@ export class AuthController {
     return(await this.authService.secondJoin(authDto));
   }
 
-  // todo: Set in UserController
-  // todo: checking when error
-  /**
-   * DELETE /serverAuth/delete?intraId=
-   */
-  @Delete('delete')
-  @ApiOperation({summary: 'remove a user info'})
-  async deleteUser(@Query('intraId') intraId:string) {
-    console.log("[ DELETE /serverAuth/delete ] requested.");
-    console.log(`?intraId: [${intraId}]`);
-    await this.authService.deleteUser(intraId); // todo: consider
-  }
-
   // todo: Remove
   // test
   @Get('test0')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -184,9 +184,4 @@ export class AuthService {
       throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.UNAUTHORIZED);
     }
   }
-
-  async deleteUser(intraId:string) {
-    // todo: Request to dbManager
-    return (await this.usersRepository.delete({ intraId: intraId }));
-  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -70,7 +70,6 @@ export class AuthService {
           intraId : res.data.login,
           password: "",                   // todo: consider
           photoUrl : res.data.image.link, // todo: consider
-          isOperator: false
         }
         console.log("getUserData from 42api 성공");
       })
@@ -138,7 +137,7 @@ export class AuthService {
       user.intraId = authDto.intraId;
       user.password = await bcrypt.hash(authDto.password, saltOrRounds);
       user.photoUrl = authDto.photoUrl;
-      user.isOperator = authDto.isOperator;
+      user.isOperator = false;
       console.log(user);
       await this.usersRepository.save(user); // todo: Request to dbManager
       return authDto.intraId;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -115,11 +115,22 @@ export class AuthService {
     // todo: Request to dbManager
     const userInfo = await this.usersRepository.findOneBy({ intraId: authDto.intraId })
 
-    if (userInfo !== null) {
-      console.log("이미 존재하는 회원");
-
+    if (userInfo !== null && (userInfo.isSignedUp === true)) {
+      console.log("이미 회원가입 한 사용자");
       // todo: consider
-      throw new HttpException({errorMessage: "이미 존재하는 회원입니다.",intraId: userInfo.intraId}, HttpStatus.FORBIDDEN);
+      throw new HttpException({errorMessage: "이미 회원가입 한 회원입니다.",intraId: userInfo.intraId}, HttpStatus.FORBIDDEN);
+    } else if (userInfo !== null) {
+      console.log("이전에 회원가입 시도(firstJoin) 한 사용자");
+    } else {
+      console.log("DB user_info table에 사용자 정보 저장");
+      const newUserInfo = this.usersRepository.create({
+        intraId: authDto.intraId,
+        password: null,
+        isOperator: false,
+        photoUrl: null,
+        isSignedUp: false,
+      });
+      await this.usersRepository.save(newUserInfo);
     }
     return (authDto);
   }
@@ -139,6 +150,7 @@ export class AuthService {
       user.password = await bcrypt.hash(authDto.password, saltOrRounds);
       user.photoUrl = authDto.photoUrl;
       user.isOperator = authDto.isOperator;
+      user.isSignedUp = true;
       console.log(user);
       await this.usersRepository.save(user); // todo: Request to dbManager
       return authDto.intraId;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -160,28 +160,23 @@ export class AuthService {
     return ; // todo: send success message ?
   }
 
-  // todo: Rename to createJwtAccessToken()
-  createrAcessToken(authDto: AuthDto) {
-    const payload = { intraId: authDto.intraId };
-    const accessToken = this.jwtService.sign(payload)
-    return (accessToken);
+  createJwtAccessToken(intraId: string): string {
+    const payload = { intraId };
+    const accessToken: string = this.jwtService.sign(payload);
+    return accessToken;
   }
 
-  async login(response:Response, authDto:AuthDto) {
-    let userInfo = await this.usersRepository.findOneBy({ intraId: authDto.intraId });
-    if (userInfo !== null) {
-      const isMatch = await bcrypt.compare(authDto.password, userInfo.password);
-      if ((userInfo.intraId == authDto.intraId) && isMatch) {
-        return(this.createrAcessToken(authDto));
-      }
-      else {
-        console.log("Wrong password -> 401 UNAUTHORIZED");
-        throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.UNAUTHORIZED);
-      }
-    }
-    else {
+  async login(authDto: AuthDto): Promise<string> {
+    const userInfo = await this.usersRepository.findOneBy({ intraId: authDto.intraId });
+    if (userInfo === null) {
       console.log("No user -> 401 UNAUTHORIZED")
       throw new HttpException('회원정보가 존재하지 않습니다.', HttpStatus.UNAUTHORIZED);
     }
+    const isMatched = await bcrypt.compare(authDto.password, userInfo.password);
+    if (isMatched === false) {
+      console.log("Wrong password -> 401 UNAUTHORIZED");
+      throw new HttpException('비밀번호가 틀렸습니다.', HttpStatus.UNAUTHORIZED);
+    }
+    return (this.createJwtAccessToken(authDto.intraId));
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -114,9 +114,19 @@ export class AuthService {
     return (retIntraIdDto);
   }
 
-  checkPasswordValid(pwd: string) {
-
-    return ;
+  checkPasswordValid(pwd: string): boolean {
+    const ruleRegex = 
+      /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^*+=-])[\da-zA-Z!@#$%^*+=-]{8,}$/;
+    // Explain : 비밀번호 길이는 8자 ~ 20자 사이
+    if (pwd.length < 8 && 20 < pwd.length) {
+      return false;
+    }
+    // Explain : 특수문자, 대문자, 소문자, 길이 모두 확인하는 정규식
+    else if (ruleRegex.test(pwd) === false) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   //회원가입2 유저가 기입한 정보로 회원가입
@@ -138,7 +148,11 @@ export class AuthService {
     } else {
       const saltOrRounds = 10;
       // validation password
-      this.checkPasswordValid(authDto.password);
+      if (this.checkPasswordValid(authDto.password) === false) {
+        throw new HttpException({
+          errorMessage: "비밀번호 규칙 오류",
+        }, HttpStatus.UNAUTHORIZED);
+      }
       userInfo.password = await bcrypt.hash(authDto.password, saltOrRounds);
       userInfo.isSignedUp = true;
       this.usersRepository.save(userInfo);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,15 +1,12 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { HttpService } from '@nestjs/axios'
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { JwtService } from '@nestjs/jwt';
-import { Response } from 'express';
-import * as bcrypt from 'bcrypt';
 import { AuthDto } from './dto/auth.dto';
-import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
 import { IntraIdDto } from './dto/intraId.dto';
-import { validateHeaderValue } from 'http';
-
+import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
+import * as bcrypt from 'bcrypt';
+import { Repository } from 'typeorm';
+import { HttpService } from '@nestjs/axios'
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 
 @Injectable()
 export class AuthService {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -144,6 +144,14 @@ export class AuthService {
       intraId: authDto.intraId
     })
     if (userInfo === null) {
+      this.usersRepository.create({
+        intraId: authDto.intraId,
+        password: await bcrypt.hash(authDto.password, saltOrRounds),
+        photoUrl: authDto.photoUrl,
+        isOperator: false,
+        
+
+      })
       // todo: using repository.create() ?
       user.intraId = authDto.intraId;
       user.password = await bcrypt.hash(authDto.password, saltOrRounds);

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -24,12 +24,4 @@ export class AuthDto {
         required: false
     })
     photoUrl : string;
-
-    @ApiProperty({
-        type: Boolean,
-        example: false,
-        description: "오퍼레이터 권한 유무",
-        required: true
-    })
-    isOperator : boolean;
 }

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -4,7 +4,7 @@ import { ApiProperty } from "@nestjs/swagger";
 export class AuthDto {
     @ApiProperty({
         type: String,
-        example: 'mgo',
+        example: 'intraid',
         description: '사용자 인트라 아이디',
         required: true
     })
@@ -17,11 +17,4 @@ export class AuthDto {
         required: true
     })
     password : string;
-
-    @ApiProperty({
-        type: String,   
-        description: '사진 URL',
-        required: false
-    })
-    photoUrl : string;
 }

--- a/src/auth/dto/intraId.dto.ts
+++ b/src/auth/dto/intraId.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class IntraIdDto {
+    @ApiProperty({
+        type: String,
+        example: 'intraid',
+        description: '사용자 인트라 아이디',
+        required: true
+    })
+    intraId : string;
+}

--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -10,5 +10,5 @@ export const typeORMConfig : TypeOrmModuleOptions = {
 	entities: [
 		__dirname + '/../**/*.entity.{js,ts}'
 	],
-	synchronize: false		// deploy할 때 false로 해야 DB table columns가 안전함
+	synchronize: true		// deploy할 때 false로 해야 DB table columns가 안전함
 }

--- a/src/dbmanager/entities/user_info.entity.ts
+++ b/src/dbmanager/entities/user_info.entity.ts
@@ -10,7 +10,7 @@ export class UserInfo {
 	@Column({name: "intra_id"})
 	intraId: string;
 
-	@Column({name: "password"})
+	@Column({name: "password", nullable: true})
 	password: string;
 
 	@Column({name: "is_operator"})
@@ -18,6 +18,9 @@ export class UserInfo {
 
 	@Column({name: "photo_url", nullable: true})
 	photoUrl: string;
+
+	@Column({name: "is_signed_up"})
+	isSignedUp: boolean;
 
 	@OneToMany(
 		() => Attendance, 


### PR DESCRIPTION
## 회원가입 API 검증 보완
### firstJoin
- [x] DB user_info table에 is_signed_up column 추가하기
- [x] firstJoin 요청이 들어올 때, 사용자를 user_info DB에 저장하기
	- 초기에 user_info에 저장할 때 isSignedUp의 기본 값을 false로 설정하기
- [x] firstJoin 에서 user_info의 photoUrl도 저장하기
- [x] firstJoin 응답 object에 intraId 만 넣기 -> IntraIdDto
	- [x] Front-end 에서 firstJoin의 응답 body에 photoUrl 제거 알리기
### secondJoin
- [x] DB user_info table에 request Body에 있는 intra_id가 저장되어 있는지 확인하기
- [x] secondJoin 요청에서 Body로 들어오는 Dto에서 isOperator 속성을 제거하기
	- [x] Front-end 에서 secondJoin API 요청할 때, intraId, password 만 보내기
- [x] 백엔드에서 회원가입(secondeJoin)시 비밀번호 2차 검증하기