### PR TITLE
fix: Add await at attendanceLogAdd() in OperatorService.userAttendanc…

### DIFF
--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -219,8 +219,7 @@ export class OperatorService {
 		const attendnaceLog: Attendance = await this.dbmanagerService.getAttendance(userInfo, dayInfo)
 		if (attendnaceLog) {
 			throw new BadRequestException("Attendance information already exists")
-		}
-		else {
+		} else {
 			const date = new Date(
 				attendanceData.year,
 				attendanceData.month - 1,
@@ -232,9 +231,7 @@ export class OperatorService {
 			if (!monthlyUser) {
 				monthlyUser = await this.dbmanagerService.createMonthlyUserByMonthInfo(userInfo, monthInfo)
 			}
-			this.dbmanagerService.attendanceLogAdd(userInfo, dayInfo, date)
-			//await this.dbmanagerService.increaseOneToMonthlyUserAttendanceCount(monthlyUser, date)
-			//await this.updatePerfectStatus(monthlyUser, monthInfo.currentAttendance)
+			await this.dbmanagerService.attendanceLogAdd(userInfo, dayInfo, date)
 			await this.statisticService.updateMonthlyUserAttendanceCountAndPerfectStatus(monthlyUser, monthInfo);
 		}
 	}
@@ -253,16 +250,7 @@ export class OperatorService {
 			throw new NotFoundException("dayInfo that dose not exist")
 		}
 		const monthlyUser: MonthlyUsers = await this.dbmanagerService.getMonthlyUser(userInfo, monthInfo)
-		if ( await this.dbmanagerService.attendanceLogDelete(userInfo, dayInfo)) {
-			const date = new Date(
-				attendanceData.year,
-				attendanceData.month - 1,
-				attendanceData.day,
-				8,
-				30
-			)
-			// await this.dbmanagerService.decreaseMonthlyUser(monthlyUser, date)
-			// await this.updatePerfectStatus(monthlyUser, monthInfo.currentAttendance)
+		if (await this.dbmanagerService.attendanceLogDelete(userInfo, dayInfo)) {
 			await this.statisticService.updateMonthlyUserAttendanceCountAndPerfectStatus(monthlyUser, monthInfo);
 		}
 	}


### PR DESCRIPTION
## 문제
- 기존에 출석 로그가 완전히 추가되지 않았는데 monthlyUser 정보를 update 하는 코드의 오류 발견

## 해결
- await을 붙여서 `DbManagerService.attendanceLogAdd()`가 끝난 이후에 `StatisticService.updateMonthlyUserAttendanceCountAndPerfectStatus()`가 작동하도록 설정함

## commit
-  https://github.com/42Mogle/42-mogle-backend/commit/91aebad901f2bad98001bf2ae18eeb249281b84c