### PR TITLE
Feat/updating total perfect count

### DIFF
--- a/src/statistic/statistic.service.ts
+++ b/src/statistic/statistic.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotAcceptableException, NotFoundException } from '@nestjs/common';
 import { DbmanagerService } from '../dbmanager/dbmanager.service';
 import { UserInfo } from '../dbmanager/entities/user_info.entity';
 import { MonthlyUsers } from '../dbmanager/entities/monthly_users.entity';
@@ -82,6 +82,9 @@ export class StatisticService {
 	}
 
 	async updateMonthlyUsersInASpecificMonth(year: number, month: number) {
+		if (year === 2022 && month === 11) {
+			throw new NotAcceptableException('forbidden to update 2022.11');
+		}
 		const monthInfo: MonthInfo = await this.dbmanagerService.getMonthInfo(month, year);
 		const monthlyUsers: MonthlyUsers[] = await this.dbmanagerService.getAllMonthlyUsersInAMonth(monthInfo);
 		monthlyUsers.forEach(async (monthlyUser) => {

--- a/src/statistic/statistic.service.ts
+++ b/src/statistic/statistic.service.ts
@@ -86,6 +86,7 @@ export class StatisticService {
 		const monthlyUsers: MonthlyUsers[] = await this.dbmanagerService.getAllMonthlyUsersInAMonth(monthInfo);
 		monthlyUsers.forEach(async (monthlyUser) => {
 			await this.updateMonthlyUserAttendanceCountAndPerfectStatus(monthlyUser, monthInfo);
+			await this.updateMonthlyUserTotalPerfectCount(monthlyUser, monthInfo);
 			// TODO: replace to updateMonthlyUserProperties()
 		});
 		return monthlyUsers;
@@ -147,5 +148,24 @@ export class StatisticService {
 		}
 		await this.dbmanagerService.updateMonthlyUserPerfectStatus(monthlyUser, monthlyUser.isPerfect);
 		return monthlyUser;
+	}
+
+	async updateMonthlyUserTotalPerfectCount(monthlyUser: MonthlyUsers, monthInfo: MonthInfo) {
+		const userInfo = await this.dbmanagerService.getUserInfoByMonthlyUser(monthlyUser);
+		const lastMonthlyUsersOfAUser = await this.dbmanagerService.getMonthlylUsersOfAUserInLastMonthes(userInfo, monthInfo);
+		if (lastMonthlyUsersOfAUser.length === 0) {
+			monthlyUser.totalPerfectCount = 0;
+		} else {
+			let maximumTotalPerfectCountLastMonthes = 0;
+			lastMonthlyUsersOfAUser.forEach((lastMonthlyUser) => {
+				if (lastMonthlyUser.totalPerfectCount > maximumTotalPerfectCountLastMonthes) {
+					maximumTotalPerfectCountLastMonthes = lastMonthlyUser.totalPerfectCount;
+				}
+			});
+			monthlyUser.totalPerfectCount = maximumTotalPerfectCountLastMonthes;
+		}
+		if (monthlyUser.isPerfect === true)
+			monthlyUser.totalPerfectCount += 1;
+		this.dbmanagerService.updateMonthlyUserTotalPerfectCount(monthlyUser, monthlyUser.totalPerfectCount);
 	}
 }


### PR DESCRIPTION
## 정보
- #113

## 구현 로직
1. 특정달에 대해서 이전달의 montlyUsers의 totalPerfectCount의 최대값을 사용한다.
  i. 만약 monthlyUsers가 없다면 0으로 지정한다.
2. 만약 isPerfect가 true라면 +1을 더해준다.