### PR TITLE
Refactor/set month day info

### DIFF
--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -356,7 +356,7 @@ export class DbmanagerService {
 		this.setMonthInfo();
 	}
 
-	@Cron('0 0 1 1 * *')
+	@Cron('0 1 0 1 * *')
 	setTotalMonthcron() {
 		this.logger.debug("setTotalMonthcron test")
 		this.setMonthInfo();

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -167,6 +167,15 @@ export class DbmanagerService {
 		let eachNewDayInfo: DayInfo;
 		const totalDate: number = lastDatetimeInMonth.getDate();
 		for(let eachDate = 1; eachDate <= totalDate; ++eachDate) {
+			eachNewDayInfo = await this.dayInfoRepository.findOne({
+				where: {
+					day: eachDate,
+					monthInfo: monthInfo,
+				}
+			});
+			if (eachNewDayInfo) {
+				continue ;
+			}
 			dayType = this.getDayType(new Date(monthInfo.year, monthInfo.month - 1, eachDate));
 			eachNewDayInfo = this.dayInfoRepository.create({
 				day: eachDate,
@@ -182,15 +191,23 @@ export class DbmanagerService {
 	}
 
 	async setMonthInfoWithDayInfos(monthNotIndexed: number, year: number) {
-		let newMonthInfo: MonthInfo = this.monthInfoRepository.create({
-			month: monthNotIndexed,
-			year,
-			currentAttendance: 0,
-			totalAttendance: 20,
-			perfectUserCount: 0,
-			totalUserCount: 0,
+		let newMonthInfo: MonthInfo = await this.monthInfoRepository.findOne({
+			where: {
+				year,
+				month: monthNotIndexed,
+			}
 		});
-		newMonthInfo = await this.monthInfoRepository.save(newMonthInfo);
+		if (newMonthInfo === null) {
+			newMonthInfo = this.monthInfoRepository.create({
+				month: monthNotIndexed,
+				year,
+				currentAttendance: 0,
+				totalAttendance: 20,
+				perfectUserCount: 0,
+				totalUserCount: 0,
+			});
+			newMonthInfo = await this.monthInfoRepository.save(newMonthInfo);
+		}
 		const lastDatetimeInMonth: Date = new Date(year, monthNotIndexed, 0);
 		await this.setAllDayInfosInThisMonth(newMonthInfo, lastDatetimeInMonth);
 		return newMonthInfo;

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -174,17 +174,16 @@ export class DbmanagerService {
 				type: dayType,
 				attendUserCount: 0,
 				perfectUserCount: 0,
-				todayWord: process.env.TODAY_WORD, // todo: set In .env
+				todayWord: process.env.TODAY_WORD || "뀨?",
 			})
 			await this.dayInfoRepository.save(eachNewDayInfo);
 		}
 		return ;
 	}
 
-	async setMonthInfoWithDayInfos(monthIndexed: number, year: number) {
-		const lastDatetimeInMonth: Date = new Date(year, monthIndexed, 0);
+	async setMonthInfoWithDayInfos(monthNotIndexed: number, year: number) {
 		let newMonthInfo: MonthInfo = this.monthInfoRepository.create({
-			month: monthIndexed + 1,
+			month: monthNotIndexed,
 			year,
 			currentAttendance: 0,
 			totalAttendance: 20,
@@ -192,6 +191,7 @@ export class DbmanagerService {
 			totalUserCount: 0,
 		});
 		newMonthInfo = await this.monthInfoRepository.save(newMonthInfo);
+		const lastDatetimeInMonth: Date = new Date(year, monthNotIndexed, 0);
 		await this.setAllDayInfosInThisMonth(newMonthInfo, lastDatetimeInMonth);
 		return newMonthInfo;
 	}
@@ -358,8 +358,13 @@ export class DbmanagerService {
 
 	@Cron('0 1 0 1 * *')
 	setTotalMonthcron() {
-		this.logger.debug("setTotalMonthcron test")
+		//this.logger.debug("setTotalMonthcron test")
+		this.logger.log("pid = " + process.pid, "check setTotalMonthCron");
 		this.setMonthInfo();
+		const currDatetime = new Date();
+		let monthNotIndexed = currDatetime.getMonth() + 1;
+		const year = currDatetime.getFullYear();
+		this.setMonthInfoWithDayInfos(monthNotIndexed, year);
 	}
 
 	async getThisMonthInfo() {

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -167,7 +167,7 @@ export class DbmanagerService {
 		let eachNewDayInfo: DayInfo;
 		const totalDate: number = lastDatetimeInMonth.getDate();
 		for(let eachDate = 1; eachDate <= totalDate; ++eachDate) {
-			dayType = this.getDayType(new Date(monthInfo.year, monthInfo.month - 1, eachDate)); // search: how to be more efficient ?
+			dayType = this.getDayType(new Date(monthInfo.year, monthInfo.month - 1, eachDate));
 			eachNewDayInfo = this.dayInfoRepository.create({
 				day: eachDate,
 				monthInfo: monthInfo,
@@ -359,8 +359,8 @@ export class DbmanagerService {
 	@Cron('0 1 0 1 * *')
 	setTotalMonthcron() {
 		//this.logger.debug("setTotalMonthcron test")
+		//this.setMonthInfo();
 		this.logger.log("pid = " + process.pid, "check setTotalMonthCron");
-		this.setMonthInfo();
 		const currDatetime = new Date();
 		let monthNotIndexed = currDatetime.getMonth() + 1;
 		const year = currDatetime.getFullYear();

--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -114,12 +114,12 @@ export class OperatorService {
 		console.log(`uesr_info: ${JSON.stringify(userInfo.intraId)}`);
 
 		// get month_info_id and if not existing set month_info
-		let monthIndexed = datetime.getMonth();
+		let monthNotIndexed = datetime.getMonth() + 1;
 		const year = datetime.getFullYear();
-		let monthInfo = await this.dbmanagerService.getMonthInfo(monthIndexed + 1, year);
+		let monthInfo = await this.dbmanagerService.getMonthInfo(monthNotIndexed, year);
 		if (monthInfo === null) {
 			console.log('no month_info');
-			monthInfo = await this.dbmanagerService.setMonthInfoWithDayInfos(monthIndexed, year); // todo: getMonthInfo
+			monthInfo = await this.dbmanagerService.setMonthInfoWithDayInfos(monthNotIndexed, year); // todo: getMonthInfo
 			// updateCurrentAttendanceInThisMonthInfo();
 		}
 		console.log(`monthInfo: ${JSON.stringify(monthInfo)}`);


### PR DESCRIPTION
## Feature
- 매월 1일 0시 1분에 month_info와 그 달의 day_info를 세팅하는 cron을 실행하도록 변경
  - 이유: 기존에 1시에 실행하도록 설정되어 있었는데 month_info의 current_attendance를 업데이트하는 크론도 1시에 실행되기 때문에 충돌을 피하기 위함
- month_info와 day_info를 세팅하는 중에 기존에 이미 데이터가 존재한다면 throw exception 하지 않고 continue 하도록 설정
  - 이유: month_info와 몇몇 day_info가 기존에 있어도 모든 day_info들이 없을 가능성이 있기 때문에 모든 데이터를 세팅해주기 위함