### PR TITLE
chore: Modify cron time for month_info

### DIFF
--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -409,7 +409,7 @@ export class DbmanagerService {
 		this.setMonthInfo();
 	}
 
-	@Cron('0 1 0 1 * *')
+	@Cron('45 6 0 1 * *')
 	setTotalMonthcron() {
 		//this.logger.debug("setTotalMonthcron test")
 		//this.setMonthInfo();

--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -85,10 +85,7 @@ export class OperatorService {
 			this.dbmanagerService.changeMonthlyUserPerfectStatus(monthlyUserInfo, true);
 	}
 
-	// @Cron(CronExpression.EVERY_SECOND) // for test
-	// @Cron(CronExpression.EVERY_5_SECONDS) // for test
-	// @Cron(CronExpression.MONDAY_TO_FRIDAY_AT_1AM)
-	@Cron(CronExpression.EVERY_DAY_AT_1AM)
+	@Cron(CronExpression.EVERY_DAY_AT_7AM)
 	async cronUpdateThismonthProperties() {
 		this.logger.log("pid = " + process.pid, "cronUpdateThismonthProperties");
 		const currentDatetime: Date = new Date();


### PR DESCRIPTION
## 새벽 시간대에 동작하던 cron의 작동 시간을 변경함

### 변경사항 ✅
1. month_info(이번 달)의 current_attendance를 업데이트하는 기능
    - 매일 01:00 -> 매일 07:00
2. 달 마다 month_info와 day_info 데이터 row 셋을 추가하는 기능
    - 매달 1일 00:01 -> 매달 1일 06:45

### issue
- #122
