### PR TITLE
fix: Add StatisticService.updateMonthlyUserTotalPerfectCount() after …

### DIFF
--- a/src/operator/operator.service.ts
+++ b/src/operator/operator.service.ts
@@ -279,6 +279,7 @@ export class OperatorService {
 			}
 			await this.dbmanagerService.attendanceLogAdd(userInfo, dayInfo, date)
 			await this.statisticService.updateMonthlyUserAttendanceCountAndPerfectStatus(monthlyUser, monthInfo);
+			await this.statisticService.updateMonthlyUserTotalPerfectCount(monthlyUser, monthInfo);
 		}
 	}
 
@@ -298,6 +299,7 @@ export class OperatorService {
 		const monthlyUser: MonthlyUsers = await this.dbmanagerService.getMonthlyUser(userInfo, monthInfo)
 		if (await this.dbmanagerService.attendanceLogDelete(userInfo, dayInfo)) {
 			await this.statisticService.updateMonthlyUserAttendanceCountAndPerfectStatus(monthlyUser, monthInfo);
+			await this.statisticService.updateMonthlyUserTotalPerfectCount(monthlyUser, monthInfo);
 		}
 	}
 


### PR DESCRIPTION
### Issue 🚨
- Operator가 직접 User의 출석 날짜를 업데이트 한 이후에 누적개근횟수가 반영되지 않는 문제

### Solve ✅
- Operator가 직접 User의 출석 날짜를 추가하거나 제거한 이후에 누적개근횟수를 업데이트 하는 코드 추가
