### PR TITLE
Feat/monthly half perfect user list#149

### DIFF
--- a/src/dbmanager/dbmanager.controller.ts
+++ b/src/dbmanager/dbmanager.controller.ts
@@ -29,7 +29,7 @@ export class DbmanagerController {
 	})
 	setTotalMonthInfo(@GetUserInfo() userInfo: UserInfo) {
 		console.log(`[ POST /dbmanager/set/totalMonthInfo ]`);
-		this.logger.log(`[ POST /dbmanager/set/totalMonthInfo ]`, JSON.stringify(userInfo));
+		this.logger.log(`[ POST /dbmanager/set/totalMonthInfo ]`, userInfo.intraId);
 		return this.dbmanagerService.setTotalMonthInfo(userInfo);
 	}
 	

--- a/src/dbmanager/dbmanager.service.ts
+++ b/src/dbmanager/dbmanager.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, UnauthorizedException, BadRequestException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserInfo } from 'src/dbmanager/entities/user_info.entity';
-import { Between, LessThan, LessThanOrEqual, Repository } from 'typeorm';
+import { Between, LessThan, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { Attendance } from './entities/attendance.entity';
 import { Cron } from '@nestjs/schedule';
 import { MonthInfo } from './entities/month_info.entity';
@@ -551,6 +551,30 @@ export class DbmanagerService {
 				monthInfo,
 			},
 			//select: ['userInfo','totalPerfectCount','isPerfect'],
+		});
+		return monthlyUsersInTheMonth;
+	}
+
+	async getMonthlyUsersAttendedMoreThanOrEqualCount(monthInfo: MonthInfo, count: number) {
+		if (!Number.isInteger(count)) {
+			throw new Error('count must be an integer');
+		}
+		const monthlyUsersInTheMonth = this.monthlyUsersRepository.find({
+			select: {
+				userInfo: {
+					intraId: true,
+				},
+				totalPerfectCount: true,
+				isPerfect: true,
+				attendanceCount: true
+			},
+			relations: {
+				userInfo: true,
+			},
+			where: {
+				monthInfo,
+				attendanceCount: MoreThanOrEqual(count)
+			},
 		});
 		return monthlyUsersInTheMonth;
 	}

--- a/src/operator/operator.controller.ts
+++ b/src/operator/operator.controller.ts
@@ -44,7 +44,7 @@ export class OperatorController {
 		console.log(`[ PATCH /operator/setTodayWord ] requested.`);
 		console.log(`setTodayWordDto.intraId: [${userInfo.intraId}]`);
 		console.log(`setTodayWordDto.todayWord: [${todayWordDto.todayWord}]`);
-		this.logger.log(`[ PATCH /operator/setTodayWord ] requested.`, JSON.stringify(userInfo) + JSON.stringify(todayWordDto));
+		this.logger.log(`[ PATCH /operator/setTodayWord ] requested.`, JSON.stringify(userInfo.intraId) + ' ' + JSON.stringify(todayWordDto));
 		this.operatorService.setTodayWord(todayWordDto, userInfo);
 	}
 
@@ -95,7 +95,7 @@ export class OperatorController {
 		description: 'Error: Unauthorized (Blocked by JwtAuthGuard)'
 	})
 	updateAllUsersAttendanceInfo(@GetUserInfo() userInfo: UserInfo) {
-		this.logger.log(`[ POST /operator/update/user/attendance ] requested.`, JSON.stringify(userInfo));
+		this.logger.log(`[ POST /operator/update/user/attendance ] requested.`, JSON.stringify(userInfo.intraId));
 		if (userInfo.isOperator === false)
 			throw new UnauthorizedException("Not Operator");
 		this.operatorService.updateUsersAttendanceInfo();
@@ -203,7 +203,7 @@ export class OperatorController {
 	 async updateMonthInfoProperty(@GetUserInfo() userInfo: UserInfo, @Param('year') year: number, @Param('month') month: number) {
 		 console.log("[PATCH /operator/month-info-property] requested.");
 		 console.log(`year: ${year}, month: ${month}`);
-		 this.logger.log("[PATCH /operator/month-info-property] requested.", JSON.stringify(userInfo));
+		 this.logger.log("[PATCH /operator/month-info-property] requested.", JSON.stringify(userInfo.intraId));
 		if (userInfo.isOperator === false) {
 			console.log("Not Operator")
 			throw new UnauthorizedException("Not Operator");

--- a/src/statistic/statistic.controller.ts
+++ b/src/statistic/statistic.controller.ts
@@ -43,8 +43,7 @@ export class StatisticController {
 		description: 'Forbidden'
 	})
 	async getUserAttendanceList(@GetUserInfo() userInfo: UserInfo): Promise<Attendance[]> {
-		console.log("[GET /statistic/userAttendanceList] requested.");
-		this.logger.log("[GET /statistic/userAttendanceList] requested.", JSON.stringify(userInfo));
+		this.logger.log("[GET /statistic/userAttendanceList] requested.", userInfo.intraId);
 		return await this.statisticService.getAttendanceList(userInfo);
 	}
 
@@ -76,8 +75,7 @@ export class StatisticController {
 		description: 'Forbidden'
 	})
 	async getUserAttendanceState(@GetUserInfo() userInfo: UserInfo) {
-		console.log("[GET /statistic/userAttendanceState] requested.");
-		this.logger.log("[GET /statistic/userAttendanceState] requested.", JSON.stringify(userInfo));
+		this.logger.log("[GET /statistic/userAttendanceState] requested.", userInfo.intraId);
 		return await this.statisticService.getUserMonthStatus(userInfo);
 	}
 
@@ -112,13 +110,59 @@ export class StatisticController {
 		status: 403,
 		description: 'Forbidden'
 	})
-	async getMonthlyUsersInSpecificMonth(@GetUserInfo() userInfo: UserInfo, @Param('year') year: number, @Param('month') month: number) {
+	async getMonthlyUsersInSpecificMonth(
+		@GetUserInfo() userInfo: UserInfo, 
+		@Param('year') year: number, 
+		@Param('month') month: number
+	) {
 		if (userInfo.isOperator === false) {
 			throw new ForbiddenException("오퍼레이터 권한이 없습니다.");
 		}
-		console.log("[GET /statistic/monthly_users/{year}/{month}] requested.");
-		//this.logger.log("[GET /statistic/monthly_users/{year}/{month}] requested.");
+		this.logger.log(`[GET /statistic/monthly_users/${year}/${month}] requested.`);
 		return (await this.statisticService.getMonthlyUsersInSepcificMonth(year, month));
+	}
+
+	/**
+	 * GET /statistic/monthly-users/half-perfect/{year}/{month}
+	 */
+	@Get("/monthly-users/half-perfect/:year/:month")
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth('access-token')
+	@ApiOperation({
+		summary: 'get the monthly users in specified month',
+		description: '특정달에 1/2 개근자 목록 가져오기'
+	})
+	@ApiParam({
+		name: 'year',
+		type: Number,
+	})
+	@ApiParam({
+		name: 'month',
+		type: Number,
+	})
+	@ApiResponse({
+		status: 200, 
+		description: 'Success', 
+		// todo: type: DTO로 정의하기
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Error: Unauthorized (Blocked by JwtAuthGuard: No JWT access-token)'
+	})
+	@ApiResponse({
+		status: 403,
+		description: 'Forbidden'
+	})
+	async getMonthlyHalfPerfectUsersInSpecificMonth(
+		@GetUserInfo() userInfo: UserInfo, 
+		@Param('year') year: number, 
+		@Param('month') month: number
+	) {
+		if (userInfo.isOperator === false) {
+			throw new ForbiddenException("오퍼레이터 권한이 없습니다.");
+		}
+		this.logger.log(`[GET /statistic/monthly_users/half-perfect/${year}/${month}] requested.`);
+		return (await this.statisticService.getMonthlyHalfPerfectUsersInSepcificMonth(year, month));
 	}
 
 	/**
@@ -156,8 +200,7 @@ export class StatisticController {
 		if (userInfo.isOperator === false) {
 			throw new ForbiddenException("오퍼레이터 권한이 없습니다.");
 		}
-		console.log("[PATCH /statistic/monthly-users/attendance-info/{year}/{month}] requested.");
-		//this.logger.log("[GET /statistic/monthly_users/{year}/{month}] requested.");
+		this.logger.log(`[PATCH /statistic/monthly-users/attendance-info/${year}/${month}] requested.`);
 		return (await this.statisticService.updateMonthlyUsersInASpecificMonth(year, month));
 	}
 }

--- a/src/statistic/statistic.service.ts
+++ b/src/statistic/statistic.service.ts
@@ -82,24 +82,22 @@ export class StatisticService {
 	}
 
 	async getMonthlyHalfPerfectUsersInSepcificMonth(year: number, month: number) {
-		let retHalfPerfectUserIntraIds: string[] = [];
-		const monthInfo: MonthInfo = await this.dbmanagerService.getMonthInfo(month, year);
+		const monthInfo: MonthInfo | null = await this.dbmanagerService.getMonthInfo(month, year);
 		if (monthInfo === null) {
-			throw new NotFoundException('지정된 달의 데이터가 없습니다.');
+		  throw new NotFoundException('지정된 달의 데이터가 없습니다.');
 		}
-		const halfAttendanceCount: number = Math.ceil(monthInfo.totalAttendance / 2);
-		const halfAttendedMonthlyUsers: MonthlyUsers[] = await this.dbmanagerService
-			.getMonthlyUsersAttendedMoreThanOrEqualCount(monthInfo, halfAttendanceCount);
-		halfAttendedMonthlyUsers.forEach((monthlyUser) => {
-			if (monthlyUser.attendanceCount >= halfAttendanceCount) {
-				if (monthlyUser.isPerfect === false
-				|| (monthlyUser.isPerfect === true && monthlyUser.totalPerfectCount > 5)) {
-					retHalfPerfectUserIntraIds.push(monthlyUser.userInfo.intraId);
-				}
-			}
-		});
-		return retHalfPerfectUserIntraIds;
-	}
+	
+		const halfAttendanceCount = Math.ceil(monthInfo.totalAttendance / 2);
+		const halfAttendedMonthlyUsers = await this.dbmanagerService
+		  .getMonthlyUsersAttendedMoreThanOrEqualCount(monthInfo, halfAttendanceCount);
+	
+		return halfAttendedMonthlyUsers.filter((monthlyUser) => {
+		  return (
+			monthlyUser.attendanceCount >= halfAttendanceCount &&
+			(monthlyUser.isPerfect === false || monthlyUser.totalPerfectCount > 5)
+		  )
+		})
+	  }
 
 	async updateMonthlyUsersInASpecificMonth(year: number, month: number) {
 		if (year === 2022 && month === 11) {

--- a/src/statistic/statistic.service.ts
+++ b/src/statistic/statistic.service.ts
@@ -81,6 +81,26 @@ export class StatisticService {
 		return monthlyUsersInAMonth;
 	}
 
+	async getMonthlyHalfPerfectUsersInSepcificMonth(year: number, month: number) {
+		let retHalfPerfectUserIntraIds: string[] = [];
+		const monthInfo: MonthInfo = await this.dbmanagerService.getMonthInfo(month, year);
+		if (monthInfo === null) {
+			throw new NotFoundException('지정된 달의 데이터가 없습니다.');
+		}
+		const halfAttendanceCount: number = Math.ceil(monthInfo.totalAttendance / 2);
+		const halfAttendedMonthlyUsers: MonthlyUsers[] = await this.dbmanagerService
+			.getMonthlyUsersAttendedMoreThanOrEqualCount(monthInfo, halfAttendanceCount);
+		halfAttendedMonthlyUsers.forEach((monthlyUser) => {
+			if (monthlyUser.attendanceCount >= halfAttendanceCount) {
+				if (monthlyUser.isPerfect === false
+				|| (monthlyUser.isPerfect === true && monthlyUser.totalPerfectCount > 5)) {
+					retHalfPerfectUserIntraIds.push(monthlyUser.userInfo.intraId);
+				}
+			}
+		});
+		return retHalfPerfectUserIntraIds;
+	}
+
 	async updateMonthlyUsersInASpecificMonth(year: number, month: number) {
 		if (year === 2022 && month === 11) {
 			throw new NotAcceptableException('forbidden to update 2022.11');

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -47,7 +47,7 @@ export class UserController {
 		description: 'Forbidden'
 	})
 	getUserInfo(@GetUserInfo() userInfo: UserInfo): UserInfoDto {
-		this.logger.log("[GET /user/getUserInfo] requested.", JSON.stringify(userInfo));
+		this.logger.log("[GET /user/getUserInfo] requested.", userInfo.intraId);
 		const userInfoDto: UserInfoDto = {
 			intraId: userInfo.intraId,
 			isOperator: userInfo.isOperator,


### PR DESCRIPTION
## 변경 사항

- 1/2 개근 인원 표현을 위한 Read API 추가
  - `GET /statistic/monthly-users/half-perfect/{year}/{month}` API 구현
- 위 API는 1/2 개근 조건을 충족하는 인원 IntraId 배열 데이터를 응답
  - 전체 출석 일 수의  1/2 넘을 경우 (floating number일 경우 올림(ceil) 처리)
- 개근 조건
  - 개근이 아닌 경우 || (개근일 경우 누적 개근 횟수가 5회 초과인 경우)
  - ※ 5회 '초과'로 처리한 이유
    - 이번달 내에 언제라도 개근 상태일 경우 -> 누적개근횟수를 +1
    - 5회까지 개근 업적이 반영되므로

## 관련 이슈
- #149